### PR TITLE
Add get_file operations for caching testdata files

### DIFF
--- a/ravenpy/tutorial.py
+++ b/ravenpy/tutorial.py
@@ -1,0 +1,190 @@
+"""Testing and tutorial utilities module."""
+# Most of this code copied and adapted from xarray and xclim
+import logging
+from typing import List, Optional, Sequence, Union
+from pathlib import Path
+from urllib.request import urlretrieve
+from urllib.parse import urljoin
+from urllib.error import HTTPError
+
+from xarray import open_dataset as _open_dataset
+from xarray import Dataset
+from xarray.tutorial import file_md5_checksum
+
+_default_cache_dir = Path.home() / ".raven_testing_data"
+
+LOGGER = logging.getLogger("RAVEN")
+
+__all__ = ["get_file", "open_dataset"]
+
+
+def _get(
+    fullname: Path, github_url: str, branch: str, suffix: str, cache_dir: Path,
+) -> Path:
+    cache_dir = cache_dir.absolute()
+    local_file = cache_dir / branch / fullname
+    md5name = fullname.with_suffix("{}.md5".format(suffix))
+    md5file = cache_dir / branch / md5name
+
+    if not local_file.is_file():
+        # This will always leave this directory on disk.
+        # We may want to add an option to remove it.
+        local_file.parent.mkdir(parents=True, exist_ok=True)
+
+        url = "/".join((github_url, "raw", branch, fullname.as_posix()))
+        LOGGER.info("Fetching remote file: %s" % fullname.as_posix())
+        urlretrieve(url, local_file)
+        try:
+            url = "/".join((github_url, "raw", branch, md5name.as_posix()))
+            LOGGER.info("Fetching remote file md5: %s" % fullname.as_posix())
+            urlretrieve(url, md5file)
+        except HTTPError as e:
+            msg = f"{md5name.as_posix()} not found. Aborting file retrieval."
+            local_file.unlink()
+            raise FileNotFoundError(msg) from e
+
+        localmd5 = file_md5_checksum(local_file)
+        try:
+            with open(md5file) as f:
+                remotemd5 = f.read()
+            if localmd5 != remotemd5:
+                local_file.unlink()
+                msg = """
+                    MD5 checksum does not match, try downloading dataset again.
+                    """
+                raise OSError(msg)
+        except OSError as e:
+            LOGGER.error(e)
+    return local_file
+
+
+# idea copied from xclim that borrowed it from xarray that was borrowed from Seaborn
+def get_file(
+    name: Union[str, Sequence[str]],
+    github_url: str = "https://github.com/Ouranosinc/raven-testdata",
+    branch: str = "master",
+    cache_dir: Path = _default_cache_dir,
+) -> Union[Path, List[Path]]:
+    """
+    Return a file from an online GitHub-like repository.
+    If a local copy is found then always use that to avoid network traffic.
+
+    Parameters
+    ----------
+    name : Union[str, Sequence[str]]
+        Name of the file or list/tuple of names of files containing the dataset(s) including suffixes.
+    github_url : str
+        URL to Github repository where the data is stored.
+    branch : str, optional
+        For GitHub-hosted files, the branch to download from.
+    cache_dir : Path
+        The directory in which to search for and write cached data.
+
+    Returns
+    -------
+    Union[Path, List[Path]]
+
+    See Also
+    --------
+    xarray.open_dataset
+    """
+    if isinstance(name, str):
+        fullname = Path(name)
+        suffix = fullname.suffix
+
+        return _get(
+            fullname=fullname,
+            github_url=github_url,
+            branch=branch,
+            suffix=suffix,
+            cache_dir=cache_dir,
+        )
+    elif isinstance(name, (list, tuple)):
+        files = list()
+        for n in name:
+            fullname = Path(n)
+            suffix = fullname.suffix
+            files.append(_get(
+                fullname=fullname,
+                github_url=github_url,
+                branch=branch,
+                suffix=suffix,
+                cache_dir=cache_dir,
+            ))
+        return files
+
+
+# idea copied from xclim that borrowed it from xarray that was borrowed from Seaborn
+def open_dataset(
+    name: str,
+    suffix: Optional[str] = None,
+    dap_url: Optional[str] = None,
+    github_url: str = "https://github.com/Ouranosinc/raven-testdata",
+    branch: str = "master",
+    cache: bool = True,
+    cache_dir: Path = _default_cache_dir,
+    **kwds,
+) -> Dataset:
+    """
+    Open a dataset from the online GitHub-like repository.
+    If a local copy is found then always use that to avoid network traffic.
+
+    Parameters
+    ----------
+    name : str
+        Name of the file containing the dataset. If no suffix is given, assumed
+        to be netCDF ('.nc' is appended).
+    suffix : str, optional
+        If no suffix is given, assumed to be netCDF ('.nc' is appended). For no suffix, set "".
+    dap_url : str, optional
+        URL to OPeNDAP folder where the data is stored. If supplied, supersedes github_url.
+    github_url : str
+        URL to Github repository where the data is stored.
+    branch : str, optional
+        For GitHub-hosted files, the branch to download from.
+    cache_dir : Path
+        The directory in which to search for and write cached data.
+    cache : bool
+        If True, then cache data locally for use on subsequent calls.
+    kwds : dict, optional
+        For NetCDF files, **kwds passed to xarray.open_dataset.
+
+    Returns
+    -------
+    Union[Dataset, Path]
+
+    See Also
+    --------
+    xarray.open_dataset
+    """
+    name = Path(name)
+    if suffix is None:
+        suffix = ".nc"
+    fullname = name.with_suffix(suffix)
+
+    if dap_url is not None:
+        dap_file = urljoin(dap_url, str(name))
+        try:
+            ds = _open_dataset(dap_file, **kwds)
+            return ds
+        except OSError:
+            msg = "OPeNDAP file not read. Verify that service is available."
+            LOGGER.error(msg)
+            raise
+
+    local_file = _get(
+        fullname=fullname,
+        github_url=github_url,
+        branch=branch,
+        suffix=suffix,
+        cache_dir=cache_dir,
+    )
+
+    try:
+        ds = _open_dataset(local_file, **kwds)
+        if not cache:
+            ds = ds.load()
+            local_file.unlink()
+        return ds
+    except OSError:
+        raise

--- a/ravenpy/tutorial.py
+++ b/ravenpy/tutorial.py
@@ -145,6 +145,7 @@ def query_folder(
 
     md5_files = [f["path"] for f in res["tree"] if f["path"].endswith(".md5")]
     if folder:
+        folder = "/".join("/".split(folder)) if "/" in folder else folder
         md5_files = [f for f in md5_files if folder in Path(f).parent.as_posix()]
     files = [re.sub(".md5$", "", f) for f in md5_files]
 

--- a/ravenpy/tutorial.py
+++ b/ravenpy/tutorial.py
@@ -118,13 +118,13 @@ def query_folder(
     branch: str = "master",
 ) -> List[str]:
     """
-    Return a file from an online GitHub-like repository.
-    If a local copy is found then always use that to avoid network traffic.
+    Lists the files available for retrieval from a remote git repository with get_file.
+    If provided a folder name, will perform a globbing-like filtering operation for parent folders.
 
     Parameters
     ----------
     name : str, optional
-        Relative pathname of the subfolder from the top-level.
+        Relative pathname of the sub-folder from the top-level.
     github_url : str
         URL to Github repository where the data is stored.
     branch : str, optional

--- a/ravenpy/tutorial.py
+++ b/ravenpy/tutorial.py
@@ -113,7 +113,8 @@ def get_file(
 
 # Credits to Anselme  https://stackoverflow.com/a/62003257/7322852 (CC-BY-SA 4.0)
 def query_folder(
-    name: Optional[str] = None,
+    folder: Optional[str] = None,
+    pattern: Optional[str] = None,
     github_url: str = "https://github.com/Ouranosinc/raven-testdata",
     branch: str = "master",
 ) -> List[str]:
@@ -123,8 +124,10 @@ def query_folder(
 
     Parameters
     ----------
-    name : str, optional
+    folder : str, optional
         Relative pathname of the sub-folder from the top-level.
+    pattern : str, optional
+        Regex pattern to identify a file.
     github_url : str
         URL to Github repository where the data is stored.
     branch : str, optional
@@ -141,10 +144,15 @@ def query_folder(
     res = r.json()
 
     md5_files = [f["path"] for f in res["tree"] if f["path"].endswith(".md5")]
-    if name:
-        md5_files = [f for f in md5_files if name in Path(f).parent.as_posix()]
+    if folder:
+        md5_files = [f for f in md5_files if folder in Path(f).parent.as_posix()]
+    files = [re.sub(".md5$", "", f) for f in md5_files]
 
-    return [re.sub(".md5$", "", f) for f in md5_files]
+    if pattern:
+        regex = re.compile(pattern)
+        files = [string for string in files if re.search(regex, string)]
+
+    return files
 
 
 # idea copied from xclim that borrowed it from xarray that was borrowed from Seaborn

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,7 @@ coveralls
 Sphinx
 twine
 setuptools
-Click>=7.0
+Click~=7.0
 pytest>=6.0.0
 pytest-runner
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "Click>=7.0",
+    "Click~=7.0",
     "gdal==3.0.4",
     "rasterio",
     "statsmodels",

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,7 +25,9 @@ TESTDATA["solution.rvc"] = TD / "solution.rvc"
 TESTDATA[
     "raven-gr4j-cemaneige-nc-ts"
 ] = "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
-TESTDATA["raven-gr4j-cemaneige-nc-rv"] = query_folder("raven-gr4j-cemaneige", pattern=".rv")
+TESTDATA["raven-gr4j-cemaneige-nc-rv"] = query_folder(
+    "raven-gr4j-cemaneige", pattern=".rv"
+)
 
 # (
 #     "raven-gr4j-cemaneige/raven-gr4j-salmon.rvc",
@@ -198,13 +200,7 @@ def _convert_2d(fn):
 
     # Add geometry feature variables
     for key, val in features.items():
-        ds[key] = xr.DataArray(
-            name=key,
-            data=[
-                val,
-            ],
-            dims=("region",),
-        )
+        ds[key] = xr.DataArray(name=key, data=[val], dims=("region"))
 
     return ds
 
@@ -223,21 +219,7 @@ def _convert_3d(fn):
     ds = xr.open_dataset(fn).rename({"nstations": "lat"})
 
     out = xr.Dataset(
-        coords={
-            "lon": (
-                [
-                    "lon",
-                ],
-                lon,
-            ),
-            "lat": (
-                [
-                    "lat",
-                ],
-                lat,
-            ),
-            "time": ds.time,
-        }
+        coords={"lon": (["lon"], lon), "lat": (["lat"], lat), "time": ds.time}
     )
     for v in ds.data_vars:
         if v not in ["lon", "lat"]:

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,9 +1,10 @@
 from pathlib import Path
-from urllib.request import urlretrieve
 
 import numpy as np
 import pandas as pd
 import xarray as xr
+
+from ravenpy.tutorial import query_folder
 
 VERSION = "1.0.0"
 
@@ -24,13 +25,15 @@ TESTDATA["solution.rvc"] = TD / "solution.rvc"
 TESTDATA[
     "raven-gr4j-cemaneige-nc-ts"
 ] = "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
-TESTDATA["raven-gr4j-cemaneige-nc-rv"] = (
-    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvc",
-    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvh",
-    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvi",
-    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvp",
-    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvt",
-)
+TESTDATA["raven-gr4j-cemaneige-nc-rv"] = query_folder("raven-gr4j-cemaneige", pattern=".rv")
+
+# (
+#     "raven-gr4j-cemaneige/raven-gr4j-salmon.rvc",
+#     "raven-gr4j-cemaneige/raven-gr4j-salmon.rvh",
+#     "raven-gr4j-cemaneige/raven-gr4j-salmon.rvi",
+#     "raven-gr4j-cemaneige/raven-gr4j-salmon.rvp",
+#     "raven-gr4j-cemaneige/raven-gr4j-salmon.rvt",
+# )
 
 TESTDATA["raven-mohyse-nc-ts"] = TESTDATA["raven-gr4j-cemaneige-nc-ts"]
 TESTDATA["raven-mohyse"] = TD / "raven-mohyse"

--- a/tests/common.py
+++ b/tests/common.py
@@ -21,11 +21,15 @@ TESTDATA["gr4j-cemaneige"] = {
 }
 
 TESTDATA["solution.rvc"] = TD / "solution.rvc"
-TESTDATA["raven-gr4j-cemaneige-nc-ts"] = (
-    TD / "raven-gr4j-cemaneige" / "Salmon-River-Near-Prince-George_meteo_daily.nc"
-)
-TESTDATA["raven-gr4j-cemaneige-nc-rv"] = tuple(
-    (TD / "raven-gr4j-cemaneige").glob("raven-gr4j-salmon.rv?")
+TESTDATA[
+    "raven-gr4j-cemaneige-nc-ts"
+] = "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
+TESTDATA["raven-gr4j-cemaneige-nc-rv"] = (
+    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvc",
+    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvh",
+    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvi",
+    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvp",
+    "raven-gr4j-cemaneige/raven-gr4j-salmon.rvt",
 )
 
 TESTDATA["raven-mohyse-nc-ts"] = TESTDATA["raven-gr4j-cemaneige-nc-ts"]
@@ -191,7 +195,13 @@ def _convert_2d(fn):
 
     # Add geometry feature variables
     for key, val in features.items():
-        ds[key] = xr.DataArray(name=key, data=[val,], dims=("region",),)
+        ds[key] = xr.DataArray(
+            name=key,
+            data=[
+                val,
+            ],
+            dims=("region",),
+        )
 
     return ds
 
@@ -210,7 +220,21 @@ def _convert_3d(fn):
     ds = xr.open_dataset(fn).rename({"nstations": "lat"})
 
     out = xr.Dataset(
-        coords={"lon": (["lon",], lon), "lat": (["lat",], lat), "time": ds.time}
+        coords={
+            "lon": (
+                [
+                    "lon",
+                ],
+                lon,
+            ),
+            "lat": (
+                [
+                    "lat",
+                ],
+                lat,
+            ),
+            "time": ds.time,
+        }
     )
     for v in ds.data_vars:
         if v not in ["lon", "lat"]:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,6 +6,7 @@ import pytest
 import ravenpy
 from ravenpy.models import Ostrich, Raven
 from ravenpy.models.base import get_diff_level
+from ravenpy.tutorial import get_file
 
 from .common import TESTDATA
 
@@ -16,6 +17,14 @@ class TestRaven:
     def test_gr4j(self):
         rvs = TESTDATA["raven-gr4j-cemaneige-nc-rv"]
         ts = TESTDATA["raven-gr4j-cemaneige-nc-ts"]
+
+        model = Raven()
+        model.configure(rvs)
+        model(ts)
+
+    def test_gr4j_getfile(self):
+        rvs = get_file(TESTDATA["raven-gr4j-cemaneige-nc-rv"], branch="master")
+        ts = get_file(TESTDATA["raven-gr4j-cemaneige-nc-ts"], branch="master")
 
         model = Raven()
         model.configure(rvs)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -14,15 +14,8 @@ has_singularity = ravenpy.raven_simg.exists()
 
 
 class TestRaven:
+
     def test_gr4j(self):
-        rvs = TESTDATA["raven-gr4j-cemaneige-nc-rv"]
-        ts = TESTDATA["raven-gr4j-cemaneige-nc-ts"]
-
-        model = Raven()
-        model.configure(rvs)
-        model(ts)
-
-    def test_gr4j_getfile(self):
         rvs = get_file(TESTDATA["raven-gr4j-cemaneige-nc-rv"], branch="master")
         ts = get_file(TESTDATA["raven-gr4j-cemaneige-nc-ts"], branch="master")
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import xarray
+
+from ravenpy.tutorial import _default_cache_dir, get_file, open_dataset
+
+
+class TestRemoteFileAccess:
+    dap_url = "http://test.opendap.org:80/opendap/data/nc/"
+    git_url = "https://github.com/Ouranosinc/raven-testdata"
+    branch = "master"
+
+    def test_get_file(self):
+        file = get_file(name="ostrich-hbv-ec/raven-hbv-salmon.rvi", branch=self.branch)
+
+        assert Path(_default_cache_dir).exists()
+        assert file.is_file()
+        with file.open() as f:
+            header = f.read()
+            assert ":FileType          rvi ASCII Raven 2.8.2" in header
+
+    def test_open_dataset(self):
+        ds = open_dataset(
+            name="raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc",
+            branch=self.branch,
+        )
+
+        assert (
+            Path(_default_cache_dir)
+            .joinpath( self.branch,
+                "raven-gr4j-cemaneige", "Salmon-River-Near-Prince-George_meteo_daily.nc"
+            )
+            .exists()
+        )
+        assert isinstance(ds, xarray.Dataset)
+
+    def test_open_dataset_no_cache(self):
+        ds = open_dataset(
+            name="raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily_3d.nc",
+            branch=self.branch,
+            cache=False,
+        )
+
+        assert (
+            not Path(_default_cache_dir)
+            .joinpath(
+                "raven-gr4j-cemaneige",
+                "Salmon-River-Near-Prince-George_meteo_daily_3d.nc",
+            )
+            .exists()
+        )
+        assert isinstance(ds, xarray.Dataset)
+
+    def test_dap_access(self):
+        ds = open_dataset(
+            name="20070917-MODIS_A-JPL-L2P-A2007260000000.L2_LAC_GHRSST-v01.nc",
+            dap_url=self.dap_url,
+        )
+
+        assert isinstance(ds, xarray.Dataset)

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import xarray
 
-from ravenpy.tutorial import _default_cache_dir, get_file, open_dataset
+from .common import TESTDATA
+from ravenpy.tutorial import _default_cache_dir, get_file, open_dataset, query_folder
 
 
 class TestRemoteFileAccess:
@@ -58,3 +59,27 @@ class TestRemoteFileAccess:
         )
 
         assert isinstance(ds, xarray.Dataset)
+
+
+class TestQueryFolder:
+    git_url = "https://github.com/Ouranosinc/raven-testdata"
+    branch = "master"
+
+    def test_query_folder(self):
+        all_files = query_folder()
+        assert len(all_files) == 129
+
+    def test_query_specific_folder(self):
+        folder = query_folder(folder="raven-gr4j-cemaneige", branch=self.branch)
+        print(folder)
+        assert len(folder) == 8
+
+    def test_query_folder_patterns(self):
+        mohyse = query_folder(folder="/regionalisation_data/tests/", pattern="MOHYSE", branch=self.branch)
+        assert len(mohyse) == 1
+        assert mohyse[0] == str(Path("regionalisation_data", "tests", "MOHYSE_parameters.csv"))
+
+    def test_query_folder_patterns_excessive_slashes(self):
+        mohyse = query_folder(folder="///regionalisation_data/////tests///", pattern="MOHYSE", branch=self.branch)
+        assert len(mohyse) == 1
+        assert mohyse[0] == str(Path("regionalisation_data", "tests", "MOHYSE_parameters.csv"))

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -65,6 +65,10 @@ class TestQueryFolder:
     git_url = "https://github.com/Ouranosinc/raven-testdata"
     branch = "master"
 
+    def test_get_files_with_testdata_folder(self):
+        rvs = get_file(TESTDATA["raven-gr4j-cemaneige-nc-rv"], branch="master")
+        assert len(rvs) == 5
+
     def test_query_folder(self):
         all_files = query_folder()
         assert len(all_files) == 129


### PR DESCRIPTION
Fixes #16

## What's here?

- This ports the `raven` WPS project's `get_file` operations and implements them in the testing and file caching for the testing ensemble of RavenPy

## What else?

- I've pinned Click below 8.0 as this is not yet compatible with `rasterio`, `xarray` and others.