### PR TITLE
Use bumpversion

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -10,7 +10,7 @@
             "project_slug": "ravenpy",
             "project_short_description": "A Python wrapper to setup and run the hydrologic modelling framework Raven.",
             "pypi_username": "CSHS-CWRA",
-            "version": "0.1.0",
+            "version": "0.1.3",
             "use_pytest": "y",
             "use_pypi_deployment_with_travis": "y",
             "add_pyup_badge": "y",

--- a/.cruft.json
+++ b/.cruft.json
@@ -10,7 +10,7 @@
             "project_slug": "ravenpy",
             "project_short_description": "A Python wrapper to setup and run the hydrologic modelling framework Raven.",
             "pypi_username": "CSHS-CWRA",
-            "version": "0.1.3",
+            "version": "0.1.4-beta",
             "use_pytest": "y",
             "use_pypi_deployment_with_travis": "y",
             "add_pyup_badge": "y",

--- a/ravenpy/__version__.py
+++ b/ravenpy/__version__.py
@@ -6,4 +6,4 @@
 
 __author__ = """David Huard"""
 __email__ = "huard.david@ouranos.ca"
-__version__ = "0.1.3"
+__version__ = "0.1.4-beta"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 pip
-bumpversion
+bump2version
 wheel
 watchdog
 flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,12 +4,12 @@ commit = False
 tag = False
 
 [bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
+search = version="{current_version}"
+replace = version="{new_version}'"
 
-[bumpversion:file:ravenpy/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+[bumpversion:file:ravenpy/__version__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
 
 [bumpversion:file:.cruft.json]
 search = "version": "{current_version}",

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ tag = False
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"
-replace = version="{new_version}'"
+replace = version="{new_version}"
 
 [bumpversion:file:ravenpy/__version__.py]
 search = __version__ = "{current_version}"
@@ -16,24 +16,23 @@ search = "version": "{current_version}",
 replace = "version": "{new_version}",
 
 [aliases]
-# Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
 addopts = --verbose
-filterwarnings =
+filterwarnings = 
 	ignore::UserWarning
 
 [flake8]
-exclude =
+exclude = 
 	.git,
 	docs,
 	build,
 	.eggs,
 max-line-length = 88
 max-complexity = 12
-ignore =
+ignore = 
 	C901
 	E203
 	E231
@@ -43,5 +42,5 @@ ignore =
 	F403
 	W503
 	W504
-per-file-ignores =
+per-file-ignores = 
 	tests/*:E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
-current_version = 0.1.0
-commit = True
-tag = True
+current_version = 0.1.3
+commit = False
+tag = False
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-{release}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values =
+values = 
 	beta
 	gamma
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,16 @@
 current_version = 0.1.3
 commit = False
 tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?
+serialize =
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = gamma
+values =
+	beta
+	gamma
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ setup(
     #     "dev": dev_requirements,
     # },
     url="https://github.com/CSHS-CWRA/ravenpy",
-    version="0.1.3",
+    version="0.1.4-beta",
     zip_safe=False,
     cmdclass={"install": InstallExternalDeps},
 )

--- a/setup.py
+++ b/setup.py
@@ -58,17 +58,6 @@ else:
     raise RuntimeError("Please install RavenPy in a virtual environment!")
 
 
-# def get_version():
-#     here = os.path.abspath(os.path.dirname(__file__))
-#     with open(os.path.join(here, "ravenpy/__version__.py"), "r") as f:
-#         for line in f:
-#             if line.startswith("__version__"):
-#                 delim = '"' if '"' in line else "'"
-#                 return line.split(delim)[1]
-#         else:
-#             raise RuntimeError("Unable to find version string.")
-
-
 class InstallExternalDeps(install):
     """
     Custom handler for the 'install' command, to download, extract and compile

--- a/setup.py
+++ b/setup.py
@@ -58,15 +58,15 @@ else:
     raise RuntimeError("Please install RavenPy in a virtual environment!")
 
 
-def get_version():
-    here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, "ravenpy/__version__.py"), "r") as f:
-        for line in f:
-            if line.startswith("__version__"):
-                delim = '"' if '"' in line else "'"
-                return line.split(delim)[1]
-        else:
-            raise RuntimeError("Unable to find version string.")
+# def get_version():
+#     here = os.path.abspath(os.path.dirname(__file__))
+#     with open(os.path.join(here, "ravenpy/__version__.py"), "r") as f:
+#         for line in f:
+#             if line.startswith("__version__"):
+#                 delim = '"' if '"' in line else "'"
+#                 return line.split(delim)[1]
+#         else:
+#             raise RuntimeError("Unable to find version string.")
 
 
 class InstallExternalDeps(install):
@@ -200,7 +200,7 @@ setup(
     #     "dev": dev_requirements,
     # },
     url="https://github.com/CSHS-CWRA/ravenpy",
-    version=get_version(),
+    version="0.1.3",
     zip_safe=False,
     cmdclass={"install": InstallExternalDeps},
 )


### PR DESCRIPTION
`Bumpversion` is a tool we use to get around the problem of tracking/updating versions between releases.

https://github.com/c4urself/bump2version

The API is quite simple: `bumpversion major/minor/patch` will increment the semver part that you are interested in advancing. I have ported a piece of configuration that allows one to set a version as "release-ready" as well. Bumping major will set minor and patch both to `0`, minor will reset patch to `0`. It's pretty no-nonsense.

I have disabled tagging and committing by bumpversion since it doesn't play very well with `pre-commit` and `black` sometimes, but the process of releasing/tagging is not complicated is not complicated:

In other words, to create a new tagged release:
```
$ bumpversion minor
$ git commit -m "bumped version to vX.Y+1.Z-beta"
$ bumpversion release
$ git commit -m "bumped version to vX.Y+1.Z"
$ git tag "vX.Y+1.Z"
$ git push (--tags)
```
