### PR TITLE
Fix caching bug in regionalization

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.2.1
+-----
+Fix xarray caching but in regionalization.
+
 0.2.0
 -----
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.2.1
 -----
-Fix xarray caching but in regionalization.
+Fix xarray caching bug in regionalization.
 
 0.2.0
 -----

--- a/ravenpy/utilities/regionalization.py
+++ b/ravenpy/utilities/regionalization.py
@@ -115,9 +115,10 @@ def regionalize(
     m = get_model(model)()
     qsims = []
 
-    for params in reg_params:
+    for i, params in enumerate(reg_params):
         kwds["params"] = params
-        m(overwrite=True, **kwds)
+        kwds["run_name"] = f"reg_{i}"
+        m(**kwds)
         qsims.append(m.q_sim.copy(deep=True))
 
     qsims = xr.concat(qsims, dim=cr)


### PR DESCRIPTION
A better solution would be to run the different simulations in parallel, but let's open another issue for this. 