### PR TITLE
Bugfix: point to RavenPy/data and include it

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,5 +12,5 @@ recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 
-graft data
+graft ravenpy/data
 graft ravenpy/models


### PR DESCRIPTION
A pip install of `RavenPy` was not installing the necessary HydroBASINS helper shapefiles. This fix ensures that the folder is being pointed to properly in the MANIFEST.