### PR TITLE
Few fixes after 022

### DIFF
--- a/ravenpy/models/importers.py
+++ b/ravenpy/models/importers.py
@@ -306,7 +306,7 @@ class RoutingProductGridWeightImporter:
         if self._sub_ids:
             # Here we want to extract the network of connected subbasins by going upstream via their DowSubId,
             # starting from the list supplied by the user (either directly, or via their gauge IDs).. We first
-            # build a map of downSubID -> subID for effficient lookup
+            # build a map of downSubID -> subID for efficient lookup
             downsubid_to_subids = defaultdict(set)
             for _, r in self._routing_data.iterrows():
                 downsubid_to_subids[r.DowSubId].add(r.SubId)

--- a/ravenpy/utilities/forecasting.py
+++ b/ravenpy/utilities/forecasting.py
@@ -210,11 +210,8 @@ def get_CASPAR_dataset(climate_model, date):
     """Return Caspar Dataset."""
 
     if climate_model == "GEPS":
-        file_url = (
-            "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/caspar/daily/GEPS_"
-            + dt.datetime.strftime(date, "%Y%m%d")
-            + ".nc"
-        )
+        d = dt.datetime.strftime(date, "%Y%m%d")
+        file_url = f"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/caspar/daily/GEPS_{d}.nc"
         ds = xr.open_dataset(file_url)
         # Here we also extract the times at 6-hour intervals as Raven must have
         # constant timesteps and GEPS goes to 6 hours

--- a/ravenpy/utilities/testdata.py
+++ b/ravenpy/utilities/testdata.py
@@ -41,6 +41,8 @@ def get_local_testdata(pattern: str) -> Union[Path, List[Path]]:
     if not testdata_path.exists():
         raise RuntimeError(f"{testdata_path} does not exists")
     paths = [path for path in testdata_path.glob(pattern) if path.suffix != ".md5"]
+    if not paths:
+        raise RuntimeError(f"No data found for {pattern} at {testdata_path}")
     # Return item directly when singleton, for convenience
     return paths[0] if len(paths) == 1 else paths
 

--- a/tests/test_ECCC_forecast.py
+++ b/tests/test_ECCC_forecast.py
@@ -1,11 +1,6 @@
 import datetime as dt
-import tempfile
 
-import pandas as pd
-from fiona.io import ZipMemoryFile
-import xarray as xr
 from ravenpy.models import GR4JCN
-from ravenpy.utilities import forecasting
 from ravenpy.utilities.testdata import get_local_testdata
 
 """

--- a/tests/test_NRCAN_daily.py
+++ b/tests/test_NRCAN_daily.py
@@ -1,43 +1,7 @@
 import datetime as dt
-import json
-import tempfile
-
-import xarray as xr
 
 from ravenpy.models import HMETS
 from ravenpy.utilities.testdata import get_local_testdata
-
-# Get path to ncml file for NRCan data.
-NRCAN_path = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml"
-
-# Temporary path
-filepath = tempfile.mkdtemp() + "/NRCAN_ts.nc"
-
-# Get information for given catchment, could be passed in parameter to the function
-ts = get_local_testdata(
-    "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
-)
-salmon = xr.open_dataset(ts)
-lat = salmon.lat.values[0]
-lon = salmon.lon.values[0]
-
-# Start and end dates
-start_date = dt.datetime(2006, 1, 1)
-end_date = dt.datetime(2007, 12, 31)
-
-# Get data for the covered period including a 1-degree bounding box for good measure. Eventually we will be
-# able to take the catchment polygon as a mask and average points residing inside.
-
-ds = (
-    xr.open_dataset(NRCAN_path)
-    .sel(
-        lat=slice(lat + 1, lat - 1),
-        lon=slice(lon - 1, lon + 1),
-        time=slice(start_date, end_date),
-    )
-    .mean(dim={"lat", "lon"}, keep_attrs=True)
-)
-ds.to_netcdf(filepath)
 
 
 class TestRavenNRCAN:
@@ -67,9 +31,13 @@ class TestRavenNRCAN:
             916.1947,
         )
 
+        ts = get_local_testdata("nrcan/NRCAN_2006-2007_subset.nc")
+        start_date = dt.datetime(2006, 1, 1)
+        end_date = dt.datetime(2007, 12, 31)
+
         model = HMETS()
         model(
-            ts=filepath,
+            ts=ts,
             params=params,
             start_date=start_date,
             end_date=end_date,

--- a/tests/test_bias_correction.py
+++ b/tests/test_bias_correction.py
@@ -1,51 +1,25 @@
 import xarray as xr
 import xclim.sdba as sdba
-from xclim import subset
+
+from ravenpy.utilities.testdata import get_local_testdata
 
 
 class TestBiasCorrect:
     def test_bias_correction(self):
 
-        fut_data = (
-            "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/simulations/bias_adjusted/"
-            "cmip5/nasa/nex-gddp-1.0/day_inmcm4_historical+rcp85_nex-gddp.ncml"
+        ds_fut_sub = xr.open_dataset(
+            get_local_testdata(
+                "cmip5/nasa_nex-gddp-1.0_day_inmcm4_historical+rcp85_nex-gddp_2070-2071_subset.nc",
+            )
         )
-        ref_data = (
-            "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/simulations/bias_adjusted/"
-            "cmip5/nasa/nex-gddp-1.0/day_inmcm4_historical+rcp45_nex-gddp.ncml"
+        ds_ref_sub = xr.open_dataset(
+            get_local_testdata(
+                "cmip5/nasa_nex-gddp-1.0_day_inmcm4_historical+rcp45_nex-gddp_1971-1972_subset.nc",
+            )
         )
-        hist_data = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml"
-
-        lat = 49.5
-        lon = -72.96
-
-        # Open these datasets
-        ds_fut = xr.open_dataset(fut_data)
-        ds_ref = xr.open_dataset(ref_data)
-        ds_his = xr.open_dataset(hist_data)
-
-        # Subset the data to the desired location (2x2 degree box)
-        ds_fut_sub = subset.subset_bbox(
-            ds_fut,
-            lon_bnds=[lon - 1, lon + 1],
-            lat_bnds=[lat - 1, lat + 1],
-            start_date="2070",
-            end_date="2071",
-        ).mean(dim={"lat", "lon"}, keep_attrs=True)
-        ds_ref_sub = subset.subset_bbox(
-            ds_ref,
-            lon_bnds=[lon - 1, lon + 1],
-            lat_bnds=[lat - 1, lat + 1],
-            start_date="1971",
-            end_date="1972",
-        ).mean(dim={"lat", "lon"}, keep_attrs=True)
-        ds_his_sub = subset.subset_bbox(
-            ds_his,
-            lon_bnds=[lon - 1, lon + 1],
-            lat_bnds=[lat - 1, lat + 1],
-            start_date="1971",
-            end_date="1972",
-        ).mean(dim={"lat", "lon"}, keep_attrs=True)
+        ds_his_sub = xr.open_dataset(
+            get_local_testdata("nrcan/NRCAN_1971-1972_subset.nc")
+        )
 
         group_month_nowindow = sdba.utils.Grouper("time.month")
         Adj = sdba.DetrendedQuantileMapping(

--- a/tests/test_external_dataset_access.py
+++ b/tests/test_external_dataset_access.py
@@ -1,0 +1,21 @@
+import datetime as dt
+
+import numpy as np
+import pytest
+
+from ravenpy.utilities.forecasting import get_CASPAR_dataset, get_ECCC_dataset
+
+
+@pytest.mark.online
+def test_get_CASPAR_dataset():
+    ds, _ = get_CASPAR_dataset("GEPS", dt.datetime(2018, 8, 31))
+
+
+@pytest.mark.online
+def test_get_ECCC_dataset():
+    ds, _ = get_ECCC_dataset("GEPS")
+
+    ns = np.datetime64("now") - ds.time.isel(time=0).values
+    n_hours = ns / np.timedelta64(1, "h")
+
+    assert n_hours <= 36

--- a/tests/test_hindcasting.py
+++ b/tests/test_hindcasting.py
@@ -1,10 +1,6 @@
 import datetime as dt
-import tempfile
-
-from fiona.io import ZipMemoryFile
 
 from ravenpy.models import GR4JCN
-from ravenpy.utilities import forecasting
 from ravenpy.utilities.testdata import get_local_testdata
 
 """
@@ -17,9 +13,6 @@ but this is a good proof of concept.
 
 class TestHindcasting:
     def test_hindcasting_GEPS(self, tmpdir):
-
-        # Set the hindcasting date
-        date = dt.datetime(2018, 6, 1)
 
         # Prepare a RAVEN model run using historical data, GR4JCN in this case.
         # This is a dummy run to get initial states. In a real forecast situation,
@@ -42,18 +35,8 @@ class TestHindcasting:
         # Extract the final states that will be used as the next initial states
         rvc = model.outputs["solution"]
 
-        # Collect the hindcast data for the date, location and climate model.
-        # Limited to GEPS for now, for a restricted period (2017-06-01 to 2018-08-31)
-        with open(get_local_testdata("watershed_vector/LSJ_LL.zip"), "rb") as f:
-            with ZipMemoryFile(f.read()) as z:
-                region_coll = z.open("LSJ_LL.shp")
-                fcst = forecasting.get_hindcast_day(
-                    region_coll, date, climate_model="GEPS"
-                )
-
-        # write the forecast data to file
-        ts = f"{tmpdir}/fcstfile.nc"
-        fcst.to_netcdf(ts)
+        ts20 = get_local_testdata("caspar_eccc_hindcasts/geps_watershed.nc")
+        nm = 20
 
         # It is necessary to clean the model state because the input variables of the previous
         # model are not the same as the ones provided in the forecast model. therefore, if we
@@ -65,8 +48,8 @@ class TestHindcasting:
 
         # And run the model with the forecast data.
         model(
-            ts=ts,
-            nc_index=range(fcst.dims.get("member")),
+            ts=ts20,
+            nc_index=range(nm),
             start_date=dt.datetime(2018, 6, 1),
             end_date=dt.datetime(2018, 6, 10),
             area=44250.6,
@@ -85,5 +68,6 @@ class TestHindcasting:
 
         # The model now has the forecast data generated and it has 10 days of forecasts.
         assert len(model.q_sim.values) == 10
+
         # Also see if GEPS has 20 members produced.
-        assert model.q_sim.values.shape[1] == 20
+        assert model.q_sim.values.shape[1] == nm


### PR DESCRIPTION
This PR : 
* Modifies a few tests so that they use `raven-testdata`
* Adds tests for the access of external datasets (ECCC, CASPAR)
* Makes `get_local_testdata` crash explicitly when it cannot find a file
* Fixes a typo