### PR TITLE
Allow installing binaries in develop/editable mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-from setuptools import find_packages, setup
+from setuptools import Distribution, find_packages, setup
+from setuptools.command.develop import develop
 from setuptools.command.install import install
 
 with open("README.rst") as readme_file:
@@ -42,81 +43,115 @@ dev_requirements = [
 ]
 
 
-class InstallExternalDeps(install):
-    """
-    Custom handler for the 'install' command, to download, extract and compile
-    the source code of Raven and OSTRICH and copy the resulting binaries in a location
-    available on the PATH.
-    """
-
-    user_options = install.user_options + [
-        # The format is (long option, short option, description).
-        ("with-binaries", None, "Download Raven and OSTRICH sources and compile them."),
-    ]
-
-    def initialize_options(self):
-        """Set default values for options."""
-        # Each user option must be listed here with their default value.
-        install.initialize_options(self)
-        self.with_binaries = False
-
-    def finalize_options(self):
-        install.finalize_options(self)
-
-    def install_binary_dep(self, url, name, rev_name, binary_name, make_target=""):
-        print(f"Downloading {name} source code..")
-        urllib.request.urlretrieve(
-            f"{url}/{rev_name}.zip", self.external_deps_path / f"{name}.zip"
-        )
-
-        print(f"Extracting {name} source code..")
-        with zipfile.ZipFile(self.external_deps_path / f"{name}.zip", "r") as zip_ref:
-            zip_ref.extractall(self.external_deps_path)
-
-        print(f"Compiling {name}..")
-        try:
-            subprocess.check_call(
-                f"make {make_target}",
-                cwd=self.external_deps_path / rev_name,
-                shell=True,
-            )
-        except subprocess.CalledProcessError as e:
-            print(e)
-            raise RuntimeError(f"There was an error while compiling {name}")
-
-        # Copy binary binary in a location which should be available on the PATH
-        # Note that self.install_scripts should correspond to <venv>/bin or ~/.local/bin,
-        # depending on the install context (this is to be validated)
-        target_bin_path = Path(self.install_scripts) / name
-        print(f"Copying binary to {target_bin_path}")
-        shutil.copy(
-            self.external_deps_path / rev_name / binary_name,
-            target_bin_path,
-        )
-
+# Idea taken from: https://stackoverflow.com/a/25176606/787842
+class OnlyGetScriptPath(install):
     def run(self):
-        if self.with_binaries:
-            self.external_deps_path = Path("./external_deps")
-            self.external_deps_path.mkdir(exist_ok=True)
+        # does not call install.run() by design
+        self.distribution.install_scripts = self.install_scripts
 
-            url = "http://www.civil.uwaterloo.ca/jmai/raven/"
-            self.install_binary_dep(url, "raven", "Raven-rev288", "Raven.exe")
-            self.install_binary_dep(
-                url,
-                "ostrich",
-                "Ostrich_2017-12-19_plus_progressJSON",
-                f"OstrichGCC",
-                "GCC",
+
+def get_setuptools_install_scripts_dir():
+    dist = Distribution({"cmdclass": {"install": OnlyGetScriptPath}})
+    dist.dry_run = True  # not sure if necessary, but to be safe
+    dist.parse_config_files()
+    command = dist.get_command_obj("install")
+    command.ensure_finalized()
+    command.run()
+    return dist.install_scripts
+
+
+def create_external_deps_install_class(command_cls):
+    """
+    Class factory command to implement the customized binary download + compile + install logic
+    for both the install and develop command contexts.
+    """
+
+    class InstallExternalDeps(command_cls):
+        """
+        Custom handler for the 'install' and 'develop' commands, to download, extract and compile
+        the source code of Raven and OSTRICH and copy the resulting binaries in a location
+        available on the PATH.
+        """
+
+        user_options = command_cls.user_options + [
+            # The format is (long option, short option, description).
+            (
+                "with-binaries",
+                None,
+                "Download Raven and OSTRICH sources and compile them.",
+            ),
+        ]
+
+        def initialize_options(self):
+            """Set default values for options."""
+            # Each user option must be listed here with their default value.
+            command_cls.initialize_options(self)
+            self.with_binaries = False
+
+        def finalize_options(self):
+            command_cls.finalize_options(self)
+
+        def install_binary_dep(self, url, name, rev_name, binary_name, make_target=""):
+            print(f"Downloading {name} source code..")
+            urllib.request.urlretrieve(
+                f"{url}/{rev_name}.zip", self.external_deps_path / f"{name}.zip"
             )
 
-        # This works with python setup.py install, but produces this error with pip install:
-        # ERROR: ravenpy==0.1.0 did not indicate that it installed an .egg-info directory. Only setup.py projects generating .egg-info directories are supported.
-        # super().do_egg_install()
+            print(f"Extracting {name} source code..")
+            with zipfile.ZipFile(
+                self.external_deps_path / f"{name}.zip", "r"
+            ) as zip_ref:
+                zip_ref.extractall(self.external_deps_path)
 
-        # This works with pip install, but has the problem that it ignores install_requires
-        # when running with `python setup.py install`:
-        # https://stackoverflow.com/questions/21915469/python-setuptools-install-requires-is-ignored-when-overriding-cmdclass
-        install.run(self)
+            print(f"Compiling {name}..")
+            try:
+                subprocess.check_call(
+                    f"make {make_target}",
+                    cwd=self.external_deps_path / rev_name,
+                    shell=True,
+                )
+            except subprocess.CalledProcessError as e:
+                print(e)
+                raise RuntimeError(f"There was an error while compiling {name}")
+
+            # Copy binary in a location which should be available on the PATH
+            # Note 1: if command_cls==install, self.install_scripts should correspond to <venv>/bin or ~/.local/bin
+            # Note 2: if command_cls==develop, self.install_scripts is None so we are using a trick to get the value
+            #         it would have with the install command
+            scripts_dir = self.install_scripts or get_setuptools_install_scripts_dir()
+            target_bin_path = Path(scripts_dir) / name
+            print(f"Copying binary to {target_bin_path}")
+            shutil.copy(
+                self.external_deps_path / rev_name / binary_name,
+                target_bin_path,
+            )
+
+        def run(self):
+
+            if self.with_binaries:
+                self.external_deps_path = Path("./external_deps")
+                self.external_deps_path.mkdir(exist_ok=True)
+
+                url = "http://www.civil.uwaterloo.ca/jmai/raven/"
+                self.install_binary_dep(url, "raven", "Raven-rev288", "Raven.exe")
+                self.install_binary_dep(
+                    url,
+                    "ostrich",
+                    "Ostrich_2017-12-19_plus_progressJSON",
+                    f"OstrichGCC",
+                    "GCC",
+                )
+
+            # This works with python setup.py install, but produces this error with pip install:
+            # ERROR: ravenpy==0.1.0 did not indicate that it installed an .egg-info directory. Only setup.py projects generating .egg-info directories are supported.
+            # super().do_egg_install()
+
+            # This works with pip install, but has the problem that it ignores install_requires
+            # when running with `python setup.py install`:
+            # https://stackoverflow.com/questions/21915469/python-setuptools-install-requires-is-ignored-when-overriding-cmdclass
+            command_cls.run(self)
+
+    return InstallExternalDeps
 
 
 setup(
@@ -161,5 +196,8 @@ setup(
     url="https://github.com/CSHS-CWRA/ravenpy",
     version="0.2.3",
     zip_safe=False,
-    cmdclass={"install": InstallExternalDeps},
+    cmdclass={
+        "install": create_external_deps_install_class(install),
+        "develop": create_external_deps_install_class(develop),
+    },
 )


### PR DESCRIPTION
This should fix a pain point I had for a while: the inability to use `--install-option="--with-binaries"` in editable (aka. develop) mode. The overall solution is still not perfect of course, but at least this should make it easier for the most common scenario our users want: 
1. git clone
2. pip install in editable mode
3. getting the binaries.