### PR TITLE
Add possibility that NetCDF contains NODATA in grid cells 

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,3 +201,99 @@ class TestAggregateForcingsToHRUs:
         assert abs(val[16071, 0] - 0.569977) < 1e-04
         assert abs(val[0, 50] - 0.010276) < 1e-04
         assert abs(val[16071, 50] - 0.516639) < 1e-04
+
+    def test_aggregate_forcings_to_hrus_with_nodata(self, tmp_path):
+        runner = CliRunner()
+        output_nc_file_path = tmp_path / "aggreg.nc"
+        output_weight_file_path = tmp_path / "weight_aggreg.rvt"
+        params = [
+            get_local_testdata("raven-routing-sample/VIC_test_nodata.nc"),
+            get_local_testdata("raven-routing-sample/VIC_test_nodata_weights.rvt"),
+            "-v",
+            "et",
+            "--dim-names",
+            "rlon",
+            "rlat",
+            "--output-nc-file",
+            output_nc_file_path,
+            "--output-weight-file",
+            output_weight_file_path,
+        ]
+        params = map(str, params)
+
+        result = runner.invoke(aggregate_forcings_to_hrus, params)
+
+        assert result.exit_code == 0
+        assert not result.exception
+
+        output_rvt = output_weight_file_path.read_text()
+
+        gws = GridWeightsCommand.parse(output_rvt)
+
+        new_weights = gws.data
+
+        # check new weights
+        assert new_weights[0][0] == 1  # These are the HRU-IDs
+        assert new_weights[1][0] == 2  # These are the HRU-IDs
+        assert new_weights[2][0] == 3  # These are the HRU-IDs
+
+        assert new_weights[0][1] == 0  # These need to be exactly [0,1,2,3,...,nHRU]
+        assert new_weights[1][1] == 1  # These need to be exactly [0,1,2,3,...,nHRU]
+        assert new_weights[2][1] == 2  # These need to be exactly [0,1,2,3,...,nHRU]
+
+        assert new_weights[0][2] == 1.0  # All new_weights[:][2] need to be 1.0
+        assert new_weights[1][2] == 1.0  # All new_weights[:][2] need to be 1.0
+        assert new_weights[2][2] == 1.0  # All new_weights[:][2] need to be 1.0
+
+        # check aggregated NetCDF file
+        nc_in = nc4.Dataset(output_nc_file_path, "r")
+        val = nc_in.variables["et"][:]
+        nc_in.close()
+
+        # aggregated time series for HRU #1
+        # HRU #1 = [ 10% cell 0 ; 20% cell 1 ; 30% cell 3 ; 40% cell 4 ]
+        # (cell 4 is NODATA for each time step; cell 3 is NODATA at 3rd time step)
+        assert (
+            abs(val[0, 0] - 2.8333333) < 1e-04
+        )  # = 0.1*1 + 0.2*2 + 0.3*4 + 0.4*NODATA
+        #                                           # = 0.1/0.6*1 + 0.2/0.6*2 + 0.3/0.6*4
+        assert (
+            abs(val[1, 0] - 3.0000000) < 1e-04
+        )  # = 0.1*3 + 0.2*3 + 0.3*3 + 0.4*NODATA
+        #                                           # = 0.1/0.6*3 + 0.2/0.6*3 + 0.3/0.6*3
+        assert (
+            abs(val[2, 0] - 7.3333333) < 1e-04
+        )  # = 0.1*4 + 0.2*9 + 0.3*NODATA + 0.4*NODATA
+        #                                           # = 0.1/0.3*4 + 0.2/0.3*9
+        assert (
+            abs(val[3, 0] - 2.8333333) < 1e-04
+        )  # = 0.1*1 + 0.2*2 + 0.3*4 + 0.4*NODATA
+        #                                           # = 0.1/0.6*1 + 0.2/0.6*2 + 0.3/0.6*4
+
+        # aggregated time series for HRU #2
+        # HRU #2 = [ 20% cell 1 ; 80% cell 2 ]
+        # (no cell ever contains NODATA)
+        assert abs(val[0, 1] - 2.8) < 1e-04  # = 0.2*2 + 0.8*3
+        assert abs(val[1, 1] - 3.0) < 1e-04  # = 0.2*3 + 0.8*3
+        assert abs(val[2, 1] - 6.6) < 1e-04  # = 0.2*9 + 0.8*6
+        assert abs(val[3, 1] - 2.8) < 1e-04  # = 0.2*2 + 0.8*3
+
+        # aggregated time series for HRU #3
+        # HRU #3 = [ 20% cell 1 ; 10% cell 2 ; 70% cell 5 ]
+        # (cell 5 is NODATA at 3rd time step)
+        assert abs(val[0, 2] - 4.9) < 1e-04  # = 0.2*2 + 0.1*3 + 0.7*6
+        assert abs(val[1, 2] - 3.0) < 1e-04  # = 0.2*3 + 0.1*3 + 0.7*3
+        assert abs(val[2, 2] - 8.0) < 1e-04  # = 0.2*9 + 0.1*6 + 0.7*NODATA
+        #                                    # = 0.2/(0.2+0.1)*9 + 0.1/(0.2+0.1)*6
+        assert abs(val[3, 2] - 4.9) < 1e-04  # = 0.2*2 + 0.1*3 + 0.7*6
+
+        print("val[2, 3] = ", val[2, 3].data)
+
+        # aggregated time series for HRU #4
+        # HRU #3 = [ 40% cell 3 ; 60% cell 4 ]
+        # (cell3 is NODATA at 3rd time step; cell 4 is NODATA for each time step)
+        assert abs(val[0, 3] - 4.0) < 1e-04  # = 0.4*4 + 0.6*NODATA = 1.0*4
+        assert abs(val[1, 3] - 3.0) < 1e-04  # = 0.4*3 + 0.6*NODATA = 1.0*3
+        assert val[2, 3].mask  # = 0.4*NODATA + 0.6*NODATA
+        assert abs(val[2, 3].data - 0.0) < 1e-04  # = 0.4*NODATA + 0.6*NODATA
+        assert abs(val[3, 3] - 4.0) < 1e-04  # = 0.4*4 + 0.6*NODATA = 1.0*4


### PR DESCRIPTION
In that case the weights need to be rescaled and sometimes the aggregated results contain the. NODATA too.

Needs to be accompanied by two new testate:
`raven-routing-sample/VIC_test_nodata_weights.rvt`
`raven-routing-sample/VIC_test_nodata.nc`