### PR TITLE
Add RavenError and explicit Raven_errors.txt parsing

### DIFF
--- a/ravenpy/models/__init__.py
+++ b/ravenpy/models/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from .base import Ostrich, Raven, get_average_annual_runoff
+from .base import Ostrich, Raven, RavenError, get_average_annual_runoff
 from .emulators import *
 from .multimodel import RavenMultiModel
 from .rv import HRU, LU, RV, RVI, HRUState, Sub

--- a/ravenpy/models/base.py
+++ b/ravenpy/models/base.py
@@ -52,6 +52,11 @@ RAVEN_NO_DATA_VALUE = -1.2345
 
 
 class RavenError(Exception):
+    """
+    This is an error that is meant to be raised whenever a message of type "ERROR" is found
+    in the Raven_errors.txt file resulting from a Raven (i.e. the C program) run.
+    """
+
     pass
 
 

--- a/ravenpy/models/base.py
+++ b/ravenpy/models/base.py
@@ -601,6 +601,8 @@ class Raven:
             "SIMULATION COMPLETE": False,
         }
         for p in err_filepaths:
+            # The error message for an unknown command is exceptionally on two lines
+            # (the second starts with a triple space)
             for m in re.findall("^([A-Z ]+) :(.+)(?:\n   (.+))?", p.read_text(), re.M):
                 if m[0] == "SIMULATION COMPLETE":
                     messages["SIMULATION COMPLETE"] = True

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import ravenpy
-from ravenpy.models import Ostrich, Raven
+from ravenpy.models import Ostrich, Raven, RavenError
 from ravenpy.models.base import get_diff_level
 from ravenpy.utilities.testdata import get_local_testdata
 
@@ -13,6 +13,23 @@ has_singularity = False  # ravenpy.raven_simg.exists()
 
 
 class TestRaven:
+    def test_raven_error(self):
+        rvs = get_local_testdata("raven-gr4j-cemaneige/raven-gr4j-salmon.rv?")
+        ts = get_local_testdata(
+            "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
+        )
+
+        model = Raven()
+
+        rvs_without_rvi = [p for p in rvs if p.suffix != ".rvi"]
+
+        model.configure(rvs_without_rvi)
+
+        with pytest.raises(RavenError) as exc:
+            model(ts)
+
+        assert "Cannot find or read .rvi file" in str(exc.value)
+
     def test_gr4j(self):
         rvs = get_local_testdata("raven-gr4j-cemaneige/raven-gr4j-salmon.rv?")
         ts = get_local_testdata(

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -86,7 +86,7 @@ salmon_land_hru_2 = dict(
 
 class TestGR4JCN:
     def test_error(self):
-        model = GR4JCN("/tmp/ravenpy_debug/test_error")
+        model = GR4JCN()
 
         model.rvp.params = model.params(0.529, -3.396, 407.29, 1.072, 16.9, 0.947)
 
@@ -98,7 +98,7 @@ class TestGR4JCN:
         )
 
     def test_simple(self):
-        model = GR4JCN("/tmp/ravenpy_debug/test_error")
+        model = GR4JCN()
 
         model.rvi.start_date = dt.datetime(2000, 1, 1)
         model.rvi.end_date = dt.datetime(2002, 1, 1)

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -19,6 +19,7 @@ from ravenpy.models import (
     MOHYSE,
     MOHYSE_OST,
     Raven,
+    RavenError,
     Routing,
     Sub,
     get_average_annual_runoff,
@@ -84,8 +85,20 @@ salmon_land_hru_2 = dict(
 
 
 class TestGR4JCN:
+    def test_error(self):
+        model = GR4JCN("/tmp/ravenpy_debug/test_error")
+
+        model.rvp.params = model.params(0.529, -3.396, 407.29, 1.072, 16.9, 0.947)
+
+        with pytest.raises(RavenError) as exc:
+            model(TS)
+
+        assert "CHydroUnit constructor:: HRU 1 has a negative or zero area" in str(
+            exc.value
+        )
+
     def test_simple(self):
-        model = GR4JCN()
+        model = GR4JCN("/tmp/ravenpy_debug/test_error")
 
         model.rvi.start_date = dt.datetime(2000, 1, 1)
         model.rvi.end_date = dt.datetime(2002, 1, 1)


### PR DESCRIPTION
This tries to make the RavenC error processing mechanism more explicit by doing two things:

1. Parse all the `Raven_errors.txt` messages
2. Coalesce the messages of type `ERROR` into a `RavenError` custom exception

The end goal of this is to catch this exception in RavenWPS and return it to the user as a `pywps.app.exceptions.ProcessError`, for friendlier debugging.