### PR TITLE
update to newest black (v21.4b0) and use python3.7 import conventions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.0
+    rev: v2.13.0
     hooks:
     -   id: pyupgrade
         language_version: python3
@@ -21,25 +21,25 @@ repos:
     -   id: debug-statements
         language_version: python3
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.4b0
     hooks:
     -   id: black
         language_version: python3
         args: ["--target-version", "py36"]
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
     -   id: flake8
         language_version: python3
         args: ['--config=setup.cfg']
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
+    rev: 5.8.0
     hooks:
     -   id: isort
         language_version: python3
-        args: ['--profile', 'black', '--filter-files', '--py', '36']
+        args: ['--profile', 'black', '--filter-files', '--py', '37']
 -   repo: https://github.com/pycqa/pydocstyle
-    rev: 5.1.1
+    rev: 6.0.0
     hooks:
     -   id: pydocstyle
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
     hooks:
     -   id: black
         language_version: python3
-        args: ["--target-version", "py37"]
 -   repo: https://github.com/pycqa/flake8
     rev: 3.9.1
     hooks:
@@ -37,7 +36,7 @@ repos:
     hooks:
     -   id: isort
         language_version: python3
-        args: ['--profile', 'black', '--filter-files', '--py', '37']
+        args: ['--profile', 'black', '--filter-files']
 -   repo: https://github.com/pycqa/pydocstyle
     rev: 6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
     -   id: black
         language_version: python3
-        args: ["--target-version", "py36"]
+        args: ["--target-version", "py37"]
 -   repo: https://github.com/pycqa/flake8
     rev: 3.9.1
     hooks:

--- a/ravenpy/models/commands.py
+++ b/ravenpy/models/commands.py
@@ -1,9 +1,8 @@
 import itertools
 import re
+from dataclasses import asdict, dataclass, field
 from textwrap import dedent
 from typing import Any, Dict, Optional, Tuple, Union
-
-from dataclasses import asdict, dataclass, field
 
 INDENT = " " * 4
 VALUE_PADDING = 10

--- a/ravenpy/models/emulators.py
+++ b/ravenpy/models/emulators.py
@@ -1,8 +1,8 @@
 from collections import defaultdict, namedtuple
+from dataclasses import dataclass
 from pathlib import Path
 
 import xarray as xr
-from dataclasses import dataclass
 
 from .base import Ostrich, Raven
 from .commands import BasinIndexCommand, MonthlyAverageCommand
@@ -221,7 +221,7 @@ class MOHYSE_OST(Ostrich, MOHYSE):
         )
 
     def derived_parameters(self):
-        """  Derived parameters are computed by Ostrich.  """
+        """Derived parameters are computed by Ostrich."""
         pass
 
 

--- a/ravenpy/models/rv.py
+++ b/ravenpy/models/rv.py
@@ -1,6 +1,7 @@
 import collections
 import datetime as dt
 from collections import namedtuple
+from dataclasses import dataclass, replace
 from pathlib import Path
 from textwrap import dedent
 from typing import Dict, List, Tuple
@@ -8,7 +9,6 @@ from typing import Dict, List, Tuple
 import cftime
 import six
 import xarray as xr
-from dataclasses import dataclass, replace
 from xclim.core.units import units2pint
 
 from .commands import (

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -2,12 +2,12 @@ import datetime as dt
 import os
 import tempfile
 import zipfile
+from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
 import pytest
 import xarray as xr
-from dataclasses import replace
 
 from ravenpy.models import (
     GR4JCN,


### PR DESCRIPTION
This PR does two things:
- Updates the version of black in the pre-commit configuration. For information on the new features enabled by default, see: https://github.com/psf/black/releases/tag/21.4b0
- Updates the `isort` and `black` target python to the new lowest supported version (python3.7).