### PR TITLE
Added support for EvaluationPeriod

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.6.0
 -----
 
-* Added support for EvaluationPeriod commands. Note that as a result of this, the model diagnostic property contains lists instead of a scalars.
+* Added support for EvaluationPeriod commands. Note that as a result of this, the model's `diagnostics` property contains one list per key, instead of a single scalar. Also note that for calibration,  Ostrich will use the first period and the first evaluation metric.
 
 0.5.2
 -----

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.6.0
+-----
+
+* Added support for EvaluationPeriod commands. Note that as a result of this, the model diagnostic property contains lists instead of a scalars.
+
 0.5.2
 -----
 

--- a/ravenpy/config/commands.py
+++ b/ravenpy/config/commands.py
@@ -41,6 +41,20 @@ class LinearTransform(RavenCommand):
 
 
 @dataclass
+class EvaluationPeriod(RavenCommand):
+    """:EvaluationPeriod [period_name] [start yyyy-mm-dd] [end yyyy-mm-dd]"""
+
+    name: str
+    start: str
+    end: str
+
+    template = ":EvaluationPeriod {name} {start} {end}"
+
+    def to_rv(self):
+        return self.template.format(**asdict(self))
+
+
+@dataclass
 class SubBasinsCommand(RavenCommand):
     """SubBasins command (RVH)."""
 

--- a/ravenpy/config/commands.py
+++ b/ravenpy/config/commands.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import itertools
 import re
 from abc import ABC, abstractmethod
@@ -45,8 +46,8 @@ class EvaluationPeriod(RavenCommand):
     """:EvaluationPeriod [period_name] [start yyyy-mm-dd] [end yyyy-mm-dd]"""
 
     name: str
-    start: str
-    end: str
+    start: dt.date
+    end: dt.date
 
     template = ":EvaluationPeriod {name} {start} {end}"
 

--- a/ravenpy/config/rvs.py
+++ b/ravenpy/config/rvs.py
@@ -814,6 +814,21 @@ class OST(RV):
     tmpl = """
     """
 
+    # Multiplier applied to metric before passing to minimization algorithm.
+    _evaluation_metrics_multiplier = dict(
+        NASH_SUTCLIFFE=-1,
+        LOG_NASH=-1,
+        RMSE=1,
+        PCT_BIAS=1,
+        ABSERR=1,
+        ABSMAX=1,
+        PDIFF=1,
+        TMVOL=1,
+        RCOEFF=1,
+        NSC=-1,
+        KLING_GUPTA=-1,
+    )
+
     def __init__(self, config):
         super().__init__(config)
 
@@ -859,6 +874,12 @@ class OST(RV):
             self._random_seed = value
         else:
             self._random_seed = None
+
+    @property
+    def evaluation_metric_multiplier(self):
+        """For Ostrich."""
+        m = self._config.rvi._evaluation_metrics[0]
+        return self._evaluation_metrics_multiplier[m.value]
 
     @property
     def identifier(self):

--- a/ravenpy/config/rvs.py
+++ b/ravenpy/config/rvs.py
@@ -380,7 +380,8 @@ class RVI(RV):
 
     @evaluation_metrics.setter
     def evaluation_metrics(self, values):
-        if not isinstance(values, (list, set, tuple)):
+
+        if not is_sequence(values):
             values = [values]
         ms = []
         for v in values:

--- a/ravenpy/config/rvs.py
+++ b/ravenpy/config/rvs.py
@@ -212,6 +212,7 @@ class RVI(RV):
     # come after `:SoilModel`
     _post_tmpl = """
     :EvaluationMetrics     {evaluation_metrics}
+    {evaluation_periods}
     :WriteNetcdfFormat     yes
     #:WriteForcingFunctions
     :SilentMode
@@ -307,6 +308,7 @@ class RVI(RV):
             RVI.EvaluationMetrics.NASH_SUTCLIFFE,
             RVI.EvaluationMetrics.RMSE,
         ]
+        self._evaluation_periods = []
         self._suppress_output = False
 
     def configure_from_nc_data(self, fns):
@@ -385,6 +387,17 @@ class RVI(RV):
             v = v.upper() if isinstance(v, str) else v.value
             ms.append(RVI.EvaluationMetrics(v))
         self._evaluation_metrics = ms
+
+    @property
+    def evaluation_periods(self):
+        """:EvaluationPeriod option. Instantiate with list of EvaluationPeriod commands."""
+        return "\n".join([str(p) for p in self._evaluation_periods])
+
+    @evaluation_periods.setter
+    def evaluation_periods(self, values):
+        if not isinstance(values, (list, set, tuple)):
+            values = [values]
+        self._evaluation_periods = values
 
     def _update_duration(self):
         if self.end_date is not None and self.start_date is not None:

--- a/ravenpy/config/rvs.py
+++ b/ravenpy/config/rvs.py
@@ -819,7 +819,7 @@ class OST(RV):
         NASH_SUTCLIFFE=-1,
         LOG_NASH=-1,
         RMSE=1,
-        PCT_BIAS=1,
+        PCT_BIAS="Not Supported",
         ABSERR=1,
         ABSMAX=1,
         PDIFF=1,
@@ -879,6 +879,10 @@ class OST(RV):
     def evaluation_metric_multiplier(self):
         """For Ostrich."""
         m = self._config.rvi._evaluation_metrics[0]
+        if m.name == "PCT_BIAS":
+            raise ValueError(
+                "PCT_BIAS cannot be properly minimized. Select another evaluation metric."
+            )
         return self._evaluation_metrics_multiplier[m.value]
 
     @property

--- a/ravenpy/models/base.py
+++ b/ravenpy/models/base.py
@@ -6,6 +6,7 @@ The `Raven` class is the base class that implements model setup, execution and o
 class is the base class adapting `Raven` to work with the Ostrich calibration tool.
 
 """
+import collections
 import csv
 import datetime as dt
 import operator
@@ -586,21 +587,24 @@ class Raven:
 
     @property
     def diagnostics(self):
+        """Return a nested dictionary of performance metrics keyed by diagnostic name and period. The default period
+        is called "ALL".
+        """
         diag = []
+        out = collections.defaultdict(list)
         for fn in self.ind_outputs["diagnostics"]:
             with open(fn) as f:
                 reader = csv.reader(f.readlines())
                 header = next(reader)
-                content = next(reader)
+                for row in reader:
+                    for (key, val) in zip(header, row):
+                        if "DIAG" in key:
+                            val = float(val)
+                        out[key].append(val)
 
-                out: Dict[str, Union[str, float]] = dict(zip(header, content))
                 out.pop("")
 
-            for key, val in out.items():
-                if "DIAG" in key:
-                    out[key] = float(val)
             diag.append(out)
-
         return diag if len(diag) > 1 else diag[0]
 
 

--- a/ravenpy/models/emulators/blended.py
+++ b/ravenpy/models/emulators/blended.py
@@ -330,13 +330,6 @@ class BLENDED_OST(Ostrich, BLENDED):
         ####################
 
         rvi_tmpl = """
-        :Calendar              {calendar}
-        :RunName               {run_name}-{run_index}
-        :StartDate             {start_date}
-        :EndDate               {end_date}
-        :TimeStep              {time_step}
-        :Method                ORDERED_SERIES
-
         :PotentialMeltMethod     POTMELT_HMETS
         :RainSnowFraction        {rain_snow_fraction}
         :Evaporation             {evaporation}         # PET_OUDIN
@@ -379,16 +372,6 @@ class BLENDED_OST(Ostrich, BLENDED):
                         #:SnowBalance    SNOBAL_GAWSER           MULTIPLE       MULTIPLE
           :EndProcessGroup CALCULATE_WTS par_r07 par_r08
         :EndHydrologicProcesses
-
-        #:CreateRVPTemplate
-
-        #---------------------------------------------------------
-        # Output Options
-        #
-        :EvaluationMetrics NASH_SUTCLIFFE RMSE KLING_GUPTA
-        :SuppressOutput
-        :SilentMode
-        :DontWriteWatershedStorage
         """
         self.config.rvi.set_tmpl(rvi_tmpl, is_ostrich=True)
 
@@ -686,15 +669,16 @@ class BLENDED_OST(Ostrich, BLENDED):
 
         BeginResponseVars
           #name   filename                              keyword         line    col     token
-          NS      ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
+          RawMetric  ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
         EndResponseVars
 
         BeginTiedRespVars
-          NegNS 1 NS wsum -1.00
+        # <name1> <np1> <pname 1,1 > <pname 1,2 > ... <pname 1,np1 > <type1> <type_data1>
+          Metric 1 RawMetric wsum {evaluation_metric_multiplier}
         EndTiedRespVars
 
         BeginGCOP
-          CostFunction NegNS
+          CostFunction Metric
           PenaltyFunction APM
         EndGCOP
 

--- a/ravenpy/models/emulators/gr4jcn.py
+++ b/ravenpy/models/emulators/gr4jcn.py
@@ -384,15 +384,16 @@ class GR4JCN_OST(Ostrich, GR4JCN):
 
         BeginResponseVars
           #name   filename                              keyword         line    col     token
-          NS      ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
+          RawMetric  ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
         EndResponseVars
 
         BeginTiedRespVars
-          NegNS 1 NS wsum -1.00
+        # <name1> <np1> <pname 1,1 > <pname 1,2 > ... <pname 1,np1 > <type1> <type_data1>
+          Metric 1 RawMetric wsum {evaluation_metric_multiplier}
         EndTiedRespVars
 
         BeginGCOP
-          CostFunction NegNS
+          CostFunction Metric
           PenaltyFunction APM
         EndGCOP
 

--- a/ravenpy/models/emulators/hbvec.py
+++ b/ravenpy/models/emulators/hbvec.py
@@ -536,15 +536,16 @@ class HBVEC_OST(Ostrich, HBVEC):
 
         BeginResponseVars
           #name   filename                              keyword         line    col     token
-          NS      ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
+          RawMetric  ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
         EndResponseVars
 
         BeginTiedRespVars
-          NegNS 1 NS wsum -1.00
+        # <name1> <np1> <pname 1,1 > <pname 1,2 > ... <pname 1,np1 > <type1> <type_data1>
+          Metric 1 RawMetric wsum {evaluation_metric_multiplier}
         EndTiedRespVars
 
         BeginGCOP
-          CostFunction NegNS
+          CostFunction Metric
           PenaltyFunction APM
         EndGCOP
 

--- a/ravenpy/models/emulators/hmets.py
+++ b/ravenpy/models/emulators/hmets.py
@@ -421,15 +421,16 @@ class HMETS_OST(Ostrich, HMETS):
 
         BeginResponseVars
           #name   filename                              keyword         line    col     token
-          NS      ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
+          RawMetric  ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
         EndResponseVars
 
         BeginTiedRespVars
-          NegNS 1 NS wsum -1.00
+        # <name1> <np1> <pname 1,1 > <pname 1,2 > ... <pname 1,np1 > <type1> <type_data1>
+          Metric 1 RawMetric wsum {evaluation_metric_multiplier}
         EndTiedRespVars
 
         BeginGCOP
-          CostFunction NegNS
+          CostFunction Metric
           PenaltyFunction APM
         EndGCOP
 

--- a/ravenpy/models/emulators/mohyse.py
+++ b/ravenpy/models/emulators/mohyse.py
@@ -386,15 +386,16 @@ class MOHYSE_OST(Ostrich, MOHYSE):
 
         BeginResponseVars
           #name   filename                              keyword         line    col     token
-          NS      ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
+          RawMetric  ./model/output/{run_name}-{run_index}_Diagnostics.csv;       OST_NULL        1       3       ','
         EndResponseVars
 
         BeginTiedRespVars
-          NegNS 1 NS wsum -1.00
+        # <name1> <np1> <pname 1,1 > <pname 1,2 > ... <pname 1,np1 > <type1> <type_data1>
+          Metric 1 RawMetric wsum {evaluation_metric_multiplier}
         EndTiedRespVars
 
         BeginGCOP
-          CostFunction NegNS
+          CostFunction Metric
           PenaltyFunction APM
         EndGCOP
 

--- a/tests/test_geo_utilities.py
+++ b/tests/test_geo_utilities.py
@@ -226,7 +226,7 @@ class TestGenericGeoOperations:
             geom = self.sgeo.shape(feature["geometry"])
 
         geom_properties = self.analysis.geom_prop(geom)
-        np.testing.assert_almost_equal(geom_properties["area"], 6450001762792.884, 3)
+        np.testing.assert_almost_equal(geom_properties["area"], 6450001762792.884, 1)
         np.testing.assert_almost_equal(
             geom_properties["centroid"], (1645777.7589835, -933242.1203143)
         )
@@ -312,7 +312,7 @@ class TestGenericGeoOperations:
         )
         np.testing.assert_almost_equal(transformed.centroid.x, 1645777.7589835)
         np.testing.assert_almost_equal(transformed.centroid.y, -933242.1203143)
-        np.testing.assert_almost_equal(transformed.area, 6450001762792.884, 3)
+        np.testing.assert_almost_equal(transformed.area, 6450001762792.884, 1)
 
 
 class TestGIS:

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -47,10 +47,13 @@ class TestRV:
             EvaluationPeriod("dry", "1980-01-01", "1989-12-31"),
             EvaluationPeriod("wet", "1990-01-01", "2000-12-31"),
         ]
-
         out = rvi.evaluation_periods
         assert len(out.split("\n")) == 2
         assert out.startswith(":EvaluationPeriod")
+
+        # Check date input
+        d = EvaluationPeriod("dry", dt.date(1980, 1, 1), dt.date(1989, 12, 31))
+        assert str(d) == str(rvi.evaluation_periods.splitlines()[0])
 
 
 class TestOst:

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -12,7 +12,7 @@ from ravenpy.config.commands import (
     GriddedForcingCommand,
     HRUStateVariableTableCommand,
 )
-from ravenpy.config.rvs import OST, RVC, RVH, RVI, RVP, RVT
+from ravenpy.config.rvs import OST, RVC, RVH, RVI, RVP, RVT, Config
 from ravenpy.extractors import (
     RoutingProductGridWeightExtractor,
     RoutingProductShapefileExtractor,
@@ -63,6 +63,11 @@ class TestOst:
 
         o.random_seed = 0
         assert o.random_seed == "RandomSeed 0"
+
+    def test_evaluation_metric_multiplier(self):
+        config = Config(model_cls=None)
+        config.rvi.evaluation_metrics = ["RMSE", "NASH_SUTCLIFFE"]
+        assert config.ost.evaluation_metric_multiplier == 1
 
 
 class TestRVI:

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -69,6 +69,10 @@ class TestOst:
         config.rvi.evaluation_metrics = ["RMSE", "NASH_SUTCLIFFE"]
         assert config.ost.evaluation_metric_multiplier == 1
 
+        with pytest.raises(ValueError):
+            config.rvi.evaluation_metrics = ["PCT_BIAS"]
+            config.ost.evaluation_metric_multiplier
+
 
 class TestRVI:
     def test_supress_output(self):

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -8,6 +8,7 @@ import pytest
 import ravenpy
 from ravenpy.config.commands import (
     BasinStateVariablesCommand,
+    EvaluationPeriod,
     GriddedForcingCommand,
     HRUStateVariableTableCommand,
 )
@@ -37,6 +38,19 @@ class TestRV:
 
         with pytest.raises(ValueError):
             rvi.evaluation_metrics = "JIM"
+
+    def test_evaluation_periods(self):
+        rvi = RVI(None)
+        assert rvi.evaluation_periods == ""
+
+        rvi.evaluation_periods = [
+            EvaluationPeriod("dry", "1980-01-01", "1989-12-31"),
+            EvaluationPeriod("wet", "1990-01-01", "2000-12-31"),
+        ]
+
+        out = rvi.evaluation_periods
+        assert len(out.split("\n")) == 2
+        assert out.startswith(":EvaluationPeriod")
 
 
 class TestOst:


### PR DESCRIPTION
Let's users compute diagnostics on user-defined periods. 

API change: model.diagnostics will return a dict of list instead of a dict of scalars. 

TODO: Tie into Ostrich. 