### PR TITLE
Fix XESMF/ESMF and GeoPandas segfault

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,8 +10,8 @@ dependencies:
   - cf_xarray
   - click
   - climpred >=2.1
-  - clisops >=0.6.4
-  - dask <=2021.02.0
+  - clisops ==0.5.0
+  - dask
   - fiona
   - gdal >=3.0.0
   - geopandas >=0.9
@@ -27,7 +27,7 @@ dependencies:
   - requests
   - rioxarray
   - scipy
-  - scikit-learn ==0.24.1
+  - scikit-learn ==0.24.2
   - shapely
   - statsmodels
   - xarray >=0.18

--- a/ravenpy/utilities/geoserver.py
+++ b/ravenpy/utilities/geoserver.py
@@ -435,8 +435,6 @@ def select_hybas_domain(
     if point:
         bbox = point * 2
 
-    print(bbox)
-
     for dom, fn in hybas_domains.items():
         with open(fn, "rb") as f:
             zf = fiona.io.ZipMemoryFile(f)

--- a/requirements_gis.txt
+++ b/requirements_gis.txt
@@ -1,5 +1,5 @@
 affine
-clisops>=0.5.1
+clisops==0.5.0
 fiona
 geopandas>=0.9.0
 lxml

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup_requirements = ["pip", "wheel"]
 requirements = [
     "click",
     "climpred>=2.1",
-    "dask<=2021.02.0",
+    "dask",
     "matplotlib",
     "netCDF4",
     "numpy",


### PR DESCRIPTION
It seems that GeoPandas and ESMF/XESMF really do not like each other. I managed to get to the bottom of this using the GNU debugger. 

For reference, this is the stack trace when performing GeoPandas operating with ESMF installed: https://gist.github.com/Zeitsperre/d5d5f88be82835a47e48172f3bb7be16

And here's the working env without XESMF/ESMF: https://gist.github.com/Zeitsperre/e31c3f11b745856c655157d38ef4ec42

This is a sister PR to https://github.com/Ouranosinc/raven/pull/397