### PR TITLE
Remove clisops

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -10,7 +10,7 @@
             "project_slug": "ravenpy",
             "project_short_description": "A Python wrapper to setup and run the hydrologic modelling framework Raven.",
             "pypi_username": "CSHS-CWRA",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "use_pytest": "y",
             "use_pypi_deployment_with_travis": "y",
             "add_pyup_badge": "y",

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - cf_xarray
   - click
   - climpred >=2.1
-  - clisops ==0.5.0
+#  - clisops ==0.5.0
   - dask
   - fiona
   - gdal >=3.0.0

--- a/ravenpy/__version__.py
+++ b/ravenpy/__version__.py
@@ -6,4 +6,4 @@
 
 __author__ = """David Huard"""
 __email__ = "huard.david@ouranos.ca"
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/ravenpy/utilities/forecasting.py
+++ b/ravenpy/utilities/forecasting.py
@@ -321,9 +321,13 @@ def get_subsetted_forecast(region_coll, ds, times, is_caspar):
     lat_max = region_coll.bounds[3]
 
     # Subset the data to the desired location (bounding box) and times
-    ds = ds.rio.clip_box(minx=lon_min, miny=lat_min, maxx=lon_max, maxy=lat_max).sel(
-        time=times
-    )
+    ds = ds.where(
+        (ds.lon <= lon_max)
+        & (ds.lon >= lon_min)
+        & (ds.lat <= lat_max)
+        & (ds.lat >= lat_min),
+        drop=True,
+    ).sel(time=times)
 
     # Rioxarray requires CRS definitions for variables
     # Get CRS, e.g. 4326

--- a/ravenpy/utilities/forecasting.py
+++ b/ravenpy/utilities/forecasting.py
@@ -23,7 +23,6 @@ from . import gis_import_error_message
 
 try:
     import rioxarray
-    from clisops.core import subset
 except (ImportError, ModuleNotFoundError) as e:
     msg = gis_import_error_message.format(Path(__file__).stem)
     raise ImportError(msg) from e
@@ -322,9 +321,9 @@ def get_subsetted_forecast(region_coll, ds, times, is_caspar):
     lat_max = region_coll.bounds[3]
 
     # Subset the data to the desired location (bounding box) and times
-    ds = subset.subset_bbox(
-        ds, lon_bnds=[lon_min, lon_max], lat_bnds=[lat_min, lat_max]
-    ).sel(time=times)
+    ds = ds.rio.clip_box(minx=lon_min, miny=lat_min, maxx=lon_max, maxy=lat_max).sel(
+        time=times
+    )
 
     # Rioxarray requires CRS definitions for variables
     # Get CRS, e.g. 4326

--- a/requirements_gis.txt
+++ b/requirements_gis.txt
@@ -1,5 +1,5 @@
 affine
-clisops==0.5.0
+# clisops==0.5.0
 fiona
 geopandas>=0.9.0
 lxml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ setup(
         gis=gis_requirements,
     ),
     url="https://github.com/CSHS-CWRA/ravenpy",
-    version="0.6.0",
+    version="0.6.1",
     zip_safe=False,
     cmdclass={
         "install": create_external_deps_install_class(install),


### PR DESCRIPTION
We use CLISOPS for precisely one subsetting operation that can be replicated using xarray and rioxarray. CLISOPS is quite heavy on dependencies and has a few strange behaviours, like very aggressive logging (see: https://github.com/roocs/clisops/issues/144), that we don't need. Removing it means removing many libraries we don't already use.