### PR TITLE
Replace haversine function with Haversine library

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - fiona
   - gdal >=3.0.0
   - geopandas >=0.9
+  - haversine
   - lxml
   - matplotlib
   - numpy

--- a/ravenpy/utilities/regionalization.py
+++ b/ravenpy/utilities/regionalization.py
@@ -227,7 +227,7 @@ def read_gauged_params(model):
 #     return km
 
 
-def distance(gauged, ungauged):
+def distance(gauged: pd.DataFrame, ungauged: pd.Series):
     """Return geographic distance [km] between ungauged and database of gauged catchments.
 
     Parameters

--- a/ravenpy/utilities/regionalization.py
+++ b/ravenpy/utilities/regionalization.py
@@ -196,37 +196,6 @@ def read_gauged_params(model):
     return params["NASH"], params.iloc[:, 1:]
 
 
-# def haversine(lon1, lat1, lon2, lat2):
-#     """
-#     Return the great circle distance between two points on the earth.
-#
-#     Parameters
-#     ----------
-#     lon1, lat1 : ndarray
-#         Longitude and latitude coordinates in decimal degrees.
-#     lon2, lat2 : ndarray
-#         Longitude and latitude coordinates in decimal degrees.
-#
-#     Returns
-#     -------
-#     ndarray
-#       Distance between points 1 and 2 [km].
-#
-#     """
-#     lon1, lat1, lon2, lat2 = map(np.radians, [lon1, lat1, lon2, lat2])
-#
-#     dlon = lon2 - lon1
-#     dlat = lat2 - lat1
-#
-#     a = np.sin(dlat / 2.0) ** 2 + np.cos(lat1) * np.cos(lat2) * (
-#         np.sin(dlon / 2.0) ** 2
-#     )
-#
-#     c = 2 * np.arcsin(np.sqrt(a))
-#     km = 6367 * c
-#     return km
-
-
 def distance(gauged: pd.DataFrame, ungauged: pd.Series):
     """Return geographic distance [km] between ungauged and database of gauged catchments.
 

--- a/ravenpy/utilities/regionalization.py
+++ b/ravenpy/utilities/regionalization.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 import xarray as xr
+from haversine import haversine
 
 import ravenpy.models as models
 
@@ -195,35 +196,35 @@ def read_gauged_params(model):
     return params["NASH"], params.iloc[:, 1:]
 
 
-def haversine(lon1, lat1, lon2, lat2):
-    """
-    Return the great circle distance between two points on the earth.
-
-    Parameters
-    ----------
-    lon1, lat1 : ndarray
-        Longitude and latitude coordinates in decimal degrees.
-    lon2, lat2 : ndarray
-        Longitude and latitude coordinates in decimal degrees.
-
-    Returns
-    -------
-    ndarray
-      Distance between points 1 and 2 [km].
-
-    """
-    lon1, lat1, lon2, lat2 = map(np.radians, [lon1, lat1, lon2, lat2])
-
-    dlon = lon2 - lon1
-    dlat = lat2 - lat1
-
-    a = np.sin(dlat / 2.0) ** 2 + np.cos(lat1) * np.cos(lat2) * (
-        np.sin(dlon / 2.0) ** 2
-    )
-
-    c = 2 * np.arcsin(np.sqrt(a))
-    km = 6367 * c
-    return km
+# def haversine(lon1, lat1, lon2, lat2):
+#     """
+#     Return the great circle distance between two points on the earth.
+#
+#     Parameters
+#     ----------
+#     lon1, lat1 : ndarray
+#         Longitude and latitude coordinates in decimal degrees.
+#     lon2, lat2 : ndarray
+#         Longitude and latitude coordinates in decimal degrees.
+#
+#     Returns
+#     -------
+#     ndarray
+#       Distance between points 1 and 2 [km].
+#
+#     """
+#     lon1, lat1, lon2, lat2 = map(np.radians, [lon1, lat1, lon2, lat2])
+#
+#     dlon = lon2 - lon1
+#     dlat = lat2 - lat1
+#
+#     a = np.sin(dlat / 2.0) ** 2 + np.cos(lat1) * np.cos(lat2) * (
+#         np.sin(dlon / 2.0) ** 2
+#     )
+#
+#     c = 2 * np.arcsin(np.sqrt(a))
+#     km = 6367 * c
+#     return km
 
 
 def distance(gauged, ungauged):
@@ -241,7 +242,7 @@ def distance(gauged, ungauged):
     lons, lats = gauged.longitude, gauged.latitude
 
     return pd.Series(
-        data=haversine(lons.values, lats.values, lon, lat), index=gauged.index
+        data=haversine((lats.values, lons.values), (lat, lon)), index=gauged.index
     )
 
 

--- a/ravenpy/utilities/regionalization.py
+++ b/ravenpy/utilities/regionalization.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 import xarray as xr
-from haversine import haversine
+from haversine import haversine_vector
 
 import ravenpy.models as models
 
@@ -238,11 +238,13 @@ def distance(gauged, ungauged):
       Coordinates of the ungauged catchment.
 
     """
-    lon, lat = ungauged.longitude, ungauged.latitude
-    lons, lats = gauged.longitude, gauged.latitude
+    gauged_array = np.array(list(zip(gauged.latitude.values, gauged.longitude.values)))
 
     return pd.Series(
-        data=haversine((lats.values, lons.values), (lat, lon)), index=gauged.index
+        data=haversine_vector(
+            gauged_array, np.array([ungauged.latitude, ungauged.longitude]), comb=True
+        )[0],
+        index=gauged.index,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requirements = [
     "click",
     "climpred>=2.1",
     "dask",
+    "haversine",
     "matplotlib",
     "netCDF4",
     "numpy",

--- a/tests/test_regionalisation.py
+++ b/tests/test_regionalisation.py
@@ -1,48 +1,68 @@
 import datetime as dt
 
+import numpy as np
+import pandas as pd
+
 from ravenpy.models import GR4JCN
 from ravenpy.utilities import regionalization as reg
 from ravenpy.utilities.testdata import get_local_testdata
 
 
-def test_regionalization():
-    ts = get_local_testdata(
-        "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
-    )
-    model = "GR4JCN"
-    nash, params = reg.read_gauged_params(model)
-    variables = ["latitude", "longitude", "area", "forest"]
-    props = reg.read_gauged_properties(variables)
-    ungauged_props = {
-        "latitude": 40.4848,
-        "longitude": -103.3659,
-        "area": 4250.6,
-        "forest": 0.4,
-    }
+class TestRegionalization:
+    def test_full_example(self):
+        ts = get_local_testdata(
+            "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
+        )
+        model = "GR4JCN"
+        nash, params = reg.read_gauged_params(model)
+        variables = ["latitude", "longitude", "area", "forest"]
+        props = reg.read_gauged_properties(variables)
+        ungauged_props = {
+            "latitude": 40.4848,
+            "longitude": -103.3659,
+            "area": 4250.6,
+            "forest": 0.4,
+        }
 
-    hrus = (
-        GR4JCN.LandHRU(
-            area=4250.6, elevation=843.0, latitude=40.4848, longitude=-103.3659
-        ),
-    )
+        hrus = (
+            GR4JCN.LandHRU(
+                area=4250.6, elevation=843.0, latitude=40.4848, longitude=-103.3659
+            ),
+        )
 
-    qsim, ens = reg.regionalize(
-        "SP_IDW",
-        model,
-        nash,
-        params,
-        props,
-        ungauged_props,
-        start_date=dt.datetime(2000, 1, 1),
-        end_date=dt.datetime(2002, 1, 1),
-        hrus=hrus,
-        longitude=-103.3659,
-        min_NSE=0.6,
-        size=2,
-        ts=ts,
-    )
+        qsim, ens = reg.regionalize(
+            "SP_IDW",
+            model,
+            nash,
+            params,
+            props,
+            ungauged_props,
+            start_date=dt.datetime(2000, 1, 1),
+            end_date=dt.datetime(2002, 1, 1),
+            hrus=hrus,
+            longitude=-103.3659,
+            min_NSE=0.6,
+            size=2,
+            ts=ts,
+        )
 
-    assert qsim.max() > 1
-    assert len(ens) == 2
-    assert "realization" in ens.dims
-    assert "param" in ens.dims
+        assert qsim.max() > 1
+        assert len(ens) == 2
+        assert "realization" in ens.dims
+        assert "param" in ens.dims
+
+
+class TestGreatCircle:
+    def test_haversine_vector(self):
+        places = dict()
+        places["Ouagadougou"] = dict(latitude=12.366667, longitude=-1.533333)
+        places["Nairobi"] = dict(latitude=-1.286389, longitude=36.817222)
+        places["Cairo"] = dict(latitude=30.033333, longitude=31.233333)
+        df = pd.DataFrame.from_dict(places).T
+        algiers = pd.Series(dict(latitude=36.753889, longitude=3.058889))
+
+        great_circle_vectors = reg.distance(df, algiers)
+
+        np.testing.assert_array_almost_equal(
+            great_circle_vectors, [2750.249, 5478.388, 2709.166], 3
+        )


### PR DESCRIPTION
Replaced our in-house haversine calculation with something a bit more standard/precise. `Haversine` has no additional dependencies and is available on PyPI + conda-forge.