### PR TITLE
Pin climpred below v2.1.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - affine
   - cf_xarray
   - click
-  - climpred >=2.1
+  - climpred >=2.1.0,<2.1.6
   - dask
   - fiona
   - gdal >=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup_requirements = ["pip", "wheel"]
 
 requirements = [
     "click",
-    "climpred>=2.1",
+    "climpred>=2.1,<2.1.6",
     "dask",
     "haversine",
     "matplotlib",


### PR DESCRIPTION
Pinning Climpred as it can accidentally pull in the newest xclim (v0.29) and we haven't adapted to the breaking changes yet. will need to addressed when tackling #132 