### PR TITLE
Fixes for notebooks

### DIFF
--- a/ravenpy/models/base.py
+++ b/ravenpy/models/base.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 from dataclasses import astuple, fields, is_dataclass, replace
 from pathlib import Path
 from typing import Any, Dict, List, Union, cast
+from warnings import warn
 
 import numpy as np
 import xarray as xr
@@ -46,6 +47,15 @@ class RavenError(Exception):
     """
     This is an error that is meant to be raised whenever a message of type "ERROR" is found
     in the Raven_errors.txt file resulting from a Raven (i.e. the C program) run.
+    """
+
+    pass
+
+
+class RavenWarning(Warning):
+    """
+    This is a warning corresponding to a message of type "WARNING" in the Raven_errors.txt
+    file resulting from a Raven (i.e. the C program) run.
     """
 
     pass
@@ -413,6 +423,9 @@ class Raven:
 
         if messages["ERROR"]:
             raise RavenError("\n".join(messages["ERROR"]))
+
+        for msg in messages["WARNING"]:
+            warn(msg, category=RavenWarning)
 
         assert messages["SIMULATION COMPLETE"]
 

--- a/ravenpy/models/base.py
+++ b/ravenpy/models/base.py
@@ -267,7 +267,7 @@ class Raven:
         # Create symbolic link to input files
         for fn in ts:
             if not (self.model_path / Path(fn).name).exists():
-                os.symlink(str(fn), str(self.model_path / Path(fn).name))
+                os.symlink(os.path.realpath(fn), str(self.model_path / Path(fn).name))
 
         # Create symbolic link to Raven executable
         if not self.raven_cmd.exists():


### PR DESCRIPTION
These are changes for things I am discovering in the context of working with RavenPy in a shared notebook environment (not PAVICS, to be clear) with Aida (@Idajad):

* If your input files are in the notebook environment, the symlink to the NC input was not working
* I also think it's better to make the Raven warnings more visible to the user