### PR TITLE
Adjust handling of GDAL dependency when building RavenPy on conda-forge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ gis_requirements = [
 ]
 # Special GDAL handling
 on_conda = os.getenv("CONDA_BUILD")
-if on_conda is None:
+if on_conda == "1":
+    gis_requirements.append("gdal")
+else:
     try:
         gdal_version = subprocess.run(
             ["gdal-config", "--version"], capture_output=True
@@ -64,8 +66,6 @@ if on_conda is None:
         gis_requirements.append(f"gdal=={gdal_version}")
     except subprocess.CalledProcessError:
         pass
-else:
-    gis_requirements.append("gdal")
 
 dev_requirements = gis_requirements.copy()
 dev_requirements.extend(

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 """The setup script."""
 
+import os
 import shutil
 import subprocess
 import urllib.request
@@ -54,13 +55,17 @@ gis_requirements = [
     dependency for dependency in open("requirements_gis.txt").readlines()
 ]
 # Special GDAL handling
-try:
-    gdal_version = subprocess.run(
-        ["gdal-config", "--version"], capture_output=True
-    ).stdout.decode("utf-8")
-    gis_requirements.append(f"gdal=={gdal_version}")
-except subprocess.CalledProcessError:
-    pass
+on_conda = os.getenv("CONDA_BUILD")
+if not on_conda:
+    try:
+        gdal_version = subprocess.run(
+            ["gdal-config", "--version"], capture_output=True
+        ).stdout.decode("utf-8")
+        gis_requirements.append(f"gdal=={gdal_version}")
+    except subprocess.CalledProcessError:
+        pass
+else:
+    gis_requirements.append("gdal")
 
 dev_requirements = gis_requirements.copy()
 dev_requirements.extend(

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ gis_requirements = [
 ]
 # Special GDAL handling
 on_conda = os.getenv("CONDA_BUILD")
-if not on_conda:
+if on_conda is None:
     try:
         gdal_version = subprocess.run(
             ["gdal-config", "--version"], capture_output=True


### PR DESCRIPTION
The GDAL problems in RavenPy and on conda-forge have been an issue because of a handful of problems.

In a pure Python environment:
- The Python-GDAL and GDAL C-libraries need to match exactly in version number.
- The `pip` package resolver will always install the newest version of a dependency available on PyPI.
- The solution: pin the dependency of GDAL to the version of the C-library of GDAL at install time.

When a Python package is built on Anaconda:

- Different phases of the packaging process (`build`, `host`, `run`) can - and often do - have different versions, unless they are specifically pinned.
- The workaround: pin the package to specific versions and offer those as separate built binaries.

The issue here is that pinning packages to specific dependency versions will cause them to be harder to resolve in a complex dependency environment. It also prevents us from being able to use patch releases, unless we specifically build them. Therefore, If we pin support for `GDAL ==3.1`, `3.2`, or `3.3`, we are only building/supporting the specific packages found at build time (e.g. `3.1.12`, `3.2.8`, `3.3.1`). This is likely why we have so many issues with the dependency resolver in conda-forge.

This PR changes this by examining whether the package is being built by `conda-forge`, and assumes that the dependency resolver will know that if we ask for `gdal` (`python-gdal`), the underlying `libgdal` (C-library) should be installed with a compatible version.

After this is pushed, all we need to do is rebuild both RavenPy and Raven-WPS on conda-forge with the following adjustment to their recipes to make this work:
```
build:
  ...
  script_env:
    - CONDA_BUILD
```