### PR TITLE
Add generate-hrus-from-routing-product script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,13 @@ default_language_version:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
     -   id: pyupgrade
         language_version: python3
+        args: [--py37-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
     -   id: trailing-whitespace
         language_version: python3
@@ -20,8 +21,8 @@ repos:
         language_version: python3
     -   id: debug-statements
         language_version: python3
--   repo: https://github.com/ambv/black
-    rev: 21.12b0
+-   repo: https://github.com/psf/black
+    rev: 22.1.0
     hooks:
     -   id: black
         language_version: python3
@@ -47,3 +48,14 @@ repos:
     hooks:
     -   id: check-hooks-apply
     -   id: check-useless-excludes
+
+ci:
+  autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+        for more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: ''
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+  autoupdate_schedule: weekly
+  skip: []
+  submodules: false

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,14 @@
 History
 =======
 
+0.7.X
+-----
+
+* Add ``generate-hrus-from-routing-product`` script.
+
 0.7.8
 -----
+
 * Added functionalities in Data Assimilation utils and simplified tests.
 * Removed pin on setuptools.
 * Fixed issues related to symlinks, working directory, and output filenames.
@@ -12,7 +18,8 @@ History
 
 0.7.7
 -----
-* Updated internal shapely calls to remove deprecated `.to_wkt()` methods.
+
+* Updated internal shapely calls to remove deprecated ``.to_wkt()`` methods.
 
 0.7.6
 -----
@@ -42,8 +49,8 @@ History
 0.7.2
 -----
 
-* Update cruft
-* Subclass `derived_parameters` in Ostrich emulators to avoid having to pass `params`.
+* Update cruft.
+* Subclass ``derived_parameters`` in Ostrich emulators to avoid having to pass ``params``.
 
 0.7.0
 -----

--- a/docs/ravenpy.cli.rst
+++ b/docs/ravenpy.cli.rst
@@ -28,6 +28,14 @@ ravenpy.cli.generate\_grid\_weights module
    :undoc-members:
    :show-inheritance:
 
+ravenpy.cli.generate\_hrus\_from\_routing\_product
+------------------------------------------
+
+.. automodule:: ravenpy.cli.generate_hrus_from_routing_product
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -13,3 +13,7 @@ Utility Scripts
 .. click:: ravenpy.cli:collect_subbasins_upstream_of_gauge
    :prog: ravenpy collect-subbasins-upstream-of-gauge
    :nested: full
+
+.. click:: ravenpy.cli:generate_hrus_from_routing_product
+   :prog: ravenpy generate-hrus-from-routing-product
+   :nested: full

--- a/ravenpy/__version__.py
+++ b/ravenpy/__version__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This information is located in its own file so that it can be loaded
 # without importing the main package when its dependencies are not installed.
 # See: https://packaging.python.org/guides/single-sourcing-package-version

--- a/ravenpy/cli/__init__.py
+++ b/ravenpy/cli/__init__.py
@@ -5,6 +5,7 @@ from ravenpy import __version__
 from .aggregate_forcings_to_hrus import aggregate_forcings_to_hrus
 from .collect_subbasins_upstream_of_gauge import collect_subbasins_upstream_of_gauge
 from .generate_grid_weights import generate_grid_weights
+from .generate_hrus_from_routing_product import generate_hrus_from_routing_product
 
 
 @click.group()
@@ -17,4 +18,5 @@ def main():
     cli.add_command(generate_grid_weights)
     cli.add_command(aggregate_forcings_to_hrus)
     cli.add_command(collect_subbasins_upstream_of_gauge)
+    cli.add_command(generate_hrus_from_routing_product)
     cli()

--- a/ravenpy/cli/generate_hrus_from_routing_product.py
+++ b/ravenpy/cli/generate_hrus_from_routing_product.py
@@ -194,4 +194,4 @@ def generate_hrus_from_routing_product(input_file, output):
 
     hru_info.to_file(output_file)
 
-    print(f"created {output_file}")
+    click.echo(f"Created {output_file}")

--- a/ravenpy/cli/generate_hrus_from_routing_product.py
+++ b/ravenpy/cli/generate_hrus_from_routing_product.py
@@ -1,0 +1,198 @@
+from pathlib import Path
+
+import click
+import geopandas as gpd
+import numpy as np
+
+COLUMN_NAMES_CONSTANT_HRU = [
+    "SubId",
+    "DowSubId",
+    "RivSlope",
+    "RivLength",
+    "BasSlope",
+    "BasAspect",
+    "BasArea",
+    "BkfWidth",
+    "BkfDepth",
+    "Lake_Cat",
+    "HyLakeId",
+    "LakeVol",
+    "LakeDepth",
+    "LakeArea",
+    "Laketype",
+    "Has_Gauge",
+    "MeanElev",
+    "FloodP_n",
+    "Q_Mean",
+    "Ch_n",
+    "DrainArea",
+    "Strahler",
+    "Seg_ID",
+    "Seg_order",
+    "Max_DEM",
+    "Min_DEM",
+    "DA_Obs",
+    "DA_error",
+    "Obs_NM",
+    "SRC_obs",
+    "centroid_x",
+    "centroid_y",
+    "HRU_IsLake",
+    "Landuse_ID",
+    "Soil_ID",
+    "Veg_ID",
+    "HRU_Area",
+    "HRU_ID",
+    "LAND_USE_C",
+    "VEG_C",
+    "SOIL_PROF",
+    "HRU_CenX",
+    "HRU_CenY",
+    "HRU_S_mean",
+    "HRU_A_mean",
+    "HRU_E_mean",
+    "O_ID_1",
+    "O_ID_2",
+    "geometry",
+]
+
+LAND_USE_C_LAKE = "WATER"
+LAND_USE_C_LAND = "Landuse_Land_HRU"
+SOIL_PROF_LAKE = "LAKE"
+SOIL_PROF_LAND = "Soil_Land_HRU"
+VEG_C_LAKE = "WATER"
+VEG_C_LAND = "Veg_Land_HRU"
+
+
+@click.command()
+@click.argument("input-file", type=click.Path(exists=True))
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    help="Output shapefiles (will create a folder if no extension)",
+)
+def generate_hrus_from_routing_product(input_file, output):
+    """
+    Create a new HRU shapefile by splitting every subbasin row of a Routing Product V2.1 shapefile into
+    at least a land HRU and possibly an additional lake HRU.
+
+    INPUT_FILE: Routing Product V2.1 shapefile (e.g. "drainage_region_0003_v2-1/finalcat_info_v2-1.shp").
+    """
+
+    def assign_hru_attributes(i_sub, i_hru, hru_id, is_lake_HRU):
+
+        # fist copy subbasin attribute to hru table
+        for sub_col in subbasin_info.columns:
+            if sub_col == "geometry":
+                subid = int(subbasin_info["SubId"].values[i_sub])
+                # add a  new row in hruinfo
+                hru_info.loc[i_hru, sub_col] = np.nan
+                # copy geometry to hru
+                hru_info.loc[[i_hru], sub_col] = subbasin_info.loc[
+                    [subid], sub_col
+                ].values
+            else:
+                hru_info.loc[i_hru, sub_col] = subbasin_info[sub_col].values[i_sub]
+
+        hru_info.loc[i_hru, "HRU_ID"] = hru_id
+        hru_info.loc[i_hru, "HRU_CenX"] = subbasin_info["centroid_x"].values[i_sub]
+        hru_info.loc[i_hru, "HRU_CenY"] = subbasin_info["centroid_y"].values[i_sub]
+        hru_info.loc[i_hru, "HRU_S_mean"] = subbasin_info["BasSlope"].values[i_sub]
+        hru_info.loc[i_hru, "HRU_A_mean"] = subbasin_info["BasAspect"].values[i_sub]
+        hru_info.loc[i_hru, "HRU_E_mean"] = subbasin_info["MeanElev"].values[i_sub]
+
+        # assigin hru attribute if hru is lake
+        if is_lake_HRU:
+            hru_info.loc[i_hru, "HRU_IsLake"] = 1
+            hru_info.loc[i_hru, "Soil_ID"] = -1
+            hru_info.loc[i_hru, "Veg_ID"] = -1
+            hru_info.loc[i_hru, "O_ID_1"] = -1
+            hru_info.loc[i_hru, "O_ID_2"] = -1
+            hru_info.loc[i_hru, "Landuse_ID"] = -1
+            hru_info.loc[i_hru, "HRU_Area"] = subbasin_info["LakeArea"].values[i_sub]
+            hru_info.loc[i_hru, "LAND_USE_C"] = LAND_USE_C_LAKE
+            hru_info.loc[i_hru, "SOIL_PROF"] = SOIL_PROF_LAKE
+            hru_info.loc[i_hru, "VEG_C"] = VEG_C_LAKE
+        else:
+            hru_info.loc[i_hru, "HRU_IsLake"] = -1
+            hru_info.loc[i_hru, "Soil_ID"] = 1
+            hru_info.loc[i_hru, "Veg_ID"] = 1
+            hru_info.loc[i_hru, "O_ID_1"] = 1
+            hru_info.loc[i_hru, "O_ID_2"] = 1
+            hru_info.loc[i_hru, "Landuse_ID"] = 1
+            hru_info.loc[i_hru, "HRU_Area"] = (
+                subbasin_info["BasArea"].values[i_sub]
+                - subbasin_info["LakeArea"].values[i_sub]
+            )
+            hru_info.loc[i_hru, "LAND_USE_C"] = LAND_USE_C_LAND
+            hru_info.loc[i_hru, "SOIL_PROF"] = SOIL_PROF_LAND
+            hru_info.loc[i_hru, "VEG_C"] = VEG_C_LAND
+
+    if Path(input_file).suffix == ".zip":
+        input_file = f"zip://{input_file}"
+
+    subbasin_info = gpd.read_file(input_file)
+
+    if not output:
+        p = Path(input_file)
+        output_file = p.parent / f"{p.stem}_HRUs.shp"
+    else:
+        output_file = output
+
+    # create an empty pandas table that each row will be 1 hru, columns will be
+    # hru's attributes.
+    hru_info = subbasin_info.copy(deep=True)
+
+    # dissolve by subid, the subid will be set as index
+    subbasin_info = subbasin_info.dissolve(by="SubId")
+    # copy index back to new subid
+    subbasin_info["SubId"] = subbasin_info.index
+
+    max_subbsin_id = max(subbasin_info["SubId"].values)
+
+    for col in COLUMN_NAMES_CONSTANT_HRU:
+        if col != "geometry":
+            hru_info[col] = np.nan
+
+    i_hru = 0
+
+    for i_sub in range(len(subbasin_info)):
+
+        sub_id = subbasin_info["SubId"].values[i_sub]
+
+        if subbasin_info["Lake_Cat"].values[i_sub] > 0:
+            # hru id of land will be the corresponding subbasin id
+            land_hru_id = sub_id
+            assign_hru_attributes(
+                i_sub=i_sub,
+                i_hru=i_hru,
+                hru_id=land_hru_id,
+                is_lake_HRU=False,
+            )
+
+            i_hru += 1
+
+            # hru id of lake will be subbasin id + max_subbsin_id + 10
+            lake_hru_id = land_hru_id + max_subbsin_id + 10
+            assign_hru_attributes(
+                i_sub=i_sub,
+                i_hru=i_hru,
+                hru_id=lake_hru_id,
+                is_lake_HRU=True,
+            )
+        else:
+            assign_hru_attributes(
+                i_sub=i_sub,
+                i_hru=i_hru,
+                hru_id=sub_id,
+                is_lake_HRU=False,
+            )
+
+        i_hru += 1
+
+    hru_info = hru_info.loc[hru_info["HRU_ID"] > 0]
+
+    hru_info.to_file(output_file)
+
+    print(f"created {output_file}")

--- a/ravenpy/cli/generate_hrus_from_routing_product.py
+++ b/ravenpy/cli/generate_hrus_from_routing_product.py
@@ -102,7 +102,6 @@ def generate_hrus_from_routing_product(input_file, output):
         hru_info.loc[i_hru, "HRU_A_mean"] = subbasin_info["BasAspect"].values[i_sub]
         hru_info.loc[i_hru, "HRU_E_mean"] = subbasin_info["MeanElev"].values[i_sub]
 
-        # assigin hru attribute if hru is lake
         if is_lake_HRU:
             hru_info.loc[i_hru, "HRU_IsLake"] = 1
             hru_info.loc[i_hru, "Soil_ID"] = -1

--- a/ravenpy/config/rvs.py
+++ b/ravenpy/config/rvs.py
@@ -884,14 +884,14 @@ class OST(RV):
     @max_iterations.setter
     def max_iterations(self, x):
         if x < 1:
-            raise ValueError("Max iteration should be a positive integer: {}".format(x))
+            raise ValueError(f"Max iteration should be a positive integer: {x}")
         else:
             self._max_iterations = x
 
     @property
     def random_seed(self):
         if self._random_seed is not None:
-            return "RandomSeed {}".format(self._random_seed)
+            return f"RandomSeed {self._random_seed}"
         return ""
 
     @random_seed.setter

--- a/ravenpy/models/base.py
+++ b/ravenpy/models/base.py
@@ -164,7 +164,7 @@ class Raven:
 
     @property
     def model_path(self):
-        return self.exec_path / self.model_dir / "p{:02}".format(self.psim)
+        return self.exec_path / self.model_dir / f"p{self.psim:02}"
 
     @property
     def raven_cmd(self):
@@ -555,7 +555,7 @@ class Raven:
 
         if len(files) == 0:
             if not self.config.rvi.suppress_output:
-                raise UserWarning("No output files for {} in {}.".format(pattern, path))
+                raise UserWarning(f"No output files for {pattern} in {path}.")
 
         return [f.absolute() for f in files]
 

--- a/ravenpy/models/emulators/__init__.py
+++ b/ravenpy/models/emulators/__init__.py
@@ -25,6 +25,6 @@ def get_model(name):
     model_cls = getattr(emulators, name.upper(), None)
 
     if model_cls is None:
-        raise ValueError("Model {} is not recognized.".format(name))
+        raise ValueError(f"Model {name} is not recognized.")
 
     return model_cls

--- a/ravenpy/utilities/coords.py
+++ b/ravenpy/utilities/coords.py
@@ -40,6 +40,6 @@ def param(model):
         data=np.array([f.name for f in fields(model_cls.Params)]),
         attrs={
             "standard_name": "parameter",
-            "long_name": "{} model parameter name".format(model),
+            "long_name": f"{model} model parameter name",
         },
     )

--- a/ravenpy/utilities/data_assimilation.py
+++ b/ravenpy/utilities/data_assimilation.py
@@ -139,7 +139,7 @@ def perturbation(
         out = da + xr.DataArray(r, dims=dims, coords={"time": da.time})
 
     elif dist == "gamma":
-        shape = (da ** 2) / (std * da) ** 2
+        shape = (da**2) / (std * da) ** 2
         scale = ((std * da) ** 2) / da
         r = np.nan_to_num(rs.gamma(shape=shape, scale=scale, size=size), nan=0.0)
         out = xr.DataArray(r, dims=dims, coords={"time": da.time})
@@ -195,7 +195,7 @@ def update_state(
     # Equations 4.1 from Mandel, 2006
     re = np.dot(qobs_error, qobs_error.transpose()) / n_members
     p = re + (np.dot(ha, ha.transpose())) / (n_members - 1)
-    m = np.dot(p ** -1, y)
+    m = np.dot(p**-1, y)
     z = (ha.transpose()) * m
     a = (
         x

--- a/ravenpy/utilities/forecasting.py
+++ b/ravenpy/utilities/forecasting.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Fri Jul 17 09:11:58 2020
 

--- a/ravenpy/utilities/geo.py
+++ b/ravenpy/utilities/geo.py
@@ -237,7 +237,7 @@ def generic_vector_reproject(
                         output["features"].append(feature)
                     except Exception as err:
                         LOGGER.exception(
-                            "{}: Unable to reproject feature {}".format(err, feature)
+                            f"{err}: Unable to reproject feature {feature}"
                         )
                         raise
 

--- a/ravenpy/utilities/graphs.py
+++ b/ravenpy/utilities/graphs.py
@@ -358,11 +358,11 @@ def ts_fit_graph(ts, params):
         q = np.linspace(mn, mx, 200)
         pdf = dc.pdf(q)
 
-        ps = ", ".join(["{:.1f}".format(x) for x in p.values])
+        ps = ", ".join([f"{x:.1f}" for x in p.values])
         ax.plot(q, pdf, "-", label="{}({})".format(params.attrs["scipy_dist"], ps))
 
         # Labels
-        ax.set_xlabel("{} (${:~P}$)".format(ts.long_name, units2pint(ts.units)))
+        ax.set_xlabel(f"{ts.long_name} (${units2pint(ts.units):~P}$)")
         ax.set_ylabel("Probability density")
         ax2.set_ylabel("Histogram count")
 

--- a/ravenpy/utilities/io.py
+++ b/ravenpy/utilities/io.py
@@ -109,9 +109,7 @@ def generic_extract_archive(
                 else:
                     LOGGER.debug('File extension "%s" unknown' % file)
             except Exception as e:
-                LOGGER.error(
-                    "Failed to extract sub archive {{{}}}: {{{}}}".format(arch, e)
-                )
+                LOGGER.error(f"Failed to extract sub archive {{{arch}}}: {{{e}}}")
         else:
             LOGGER.warning("No archives found. Continuing...")
             return resources

--- a/ravenpy/utilities/mk_test.py
+++ b/ravenpy/utilities/mk_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Wed Jul 29 09:16:06 2015
 @author: Michael Schramm

--- a/ravenpy/utilities/nb_graphs.py
+++ b/ravenpy/utilities/nb_graphs.py
@@ -167,7 +167,7 @@ def ts_fit_graph(ts, params):
             for (key, x) in zip(params.dparams.data, params.values)
         ]
     )
-    label = "{}({})".format(dist, ps)
+    label = f"{dist}({ps})"
 
     # PDF graphic object
     p = pdf.hvplot.line(label=label, xlabel=ts.attrs["long_name"], color="orange")

--- a/ravenpy/utilities/regionalization.py
+++ b/ravenpy/utilities/regionalization.py
@@ -137,7 +137,7 @@ def regionalize(
     ):  # Here we are replacing the mean by the IDW average, keeping attributes and dimensions.
         qsim = IDW(qsims, sdist)
     else:
-        raise ValueError("No matching algorithm for {}".format(method))
+        raise ValueError(f"No matching algorithm for {method}")
 
     # Metadata handling
     # TODO: Store the basin_name
@@ -155,10 +155,10 @@ def regionalize(
         attrs={
             "title": "Regionalization ensemble",
             "institution": "",
-            "source": "RAVEN V.{} - {}".format(m.raven_version, model),
+            "source": f"RAVEN V.{m.raven_version} - {model}",
             "history": "Created by raven regionalize.",
             "references": "",
-            "comment": "Regionalization method: {}".format(method),
+            "comment": f"Regionalization method: {method}",
         },
     )
 

--- a/ravenpy/utilities/testdata.py
+++ b/ravenpy/utilities/testdata.py
@@ -66,7 +66,7 @@ def _get(
 ) -> Path:
     cache_dir = cache_dir.absolute()
     local_file = cache_dir / branch / fullname
-    md5name = fullname.with_suffix("{}.md5".format(suffix))
+    md5name = fullname.with_suffix(f"{suffix}.md5")
     md5file = cache_dir / branch / md5name
 
     if not local_file.is_file():

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ Click
 pytest
 pytest-runner
 pytest-cov
-black==21.12b0
+black
 isort
 pre-commit
 holoviews

--- a/tests/test_climatology_ESP_verfication.py
+++ b/tests/test_climatology_ESP_verfication.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Tue Feb 23 22:25:32 2021
 


### PR DESCRIPTION
As discussed, here is the "magic" script for creating land/lake HRUs from a Routing Product V2.1 shapefile. I have cleaned it up a little, but haven't touched its core logic:

```
Usage: ravenpy generate-hrus-from-routing-product [OPTIONS] INPUT_FILE

  Create a new HRU shapefile by splitting every subbasin row of a Routing
  Product V2.1 shapefile into at least a land HRU and possibly an additional
  lake HRU.

  INPUT_FILE: Routing Product V2.1 shapefile (e.g.
  "drainage_region_0003_v2-1/finalcat_info_v2-1.shp").

Options:
  -o, --output PATH  Output shapefiles (will create a folder if no extension)
  --help             Show this message and exit.
```