### PR TITLE
undo suppress_output changes from 0.8.0, as it breaks raven-wps

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.8.1
+-----
+
+* Undo change related to `suppress_output`, as it breaks multiple tests in raven. New `Raven._execute` method runs models but does not parse results.
+
+
 0.8.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ RavenPy
 .. image:: https://img.shields.io/pypi/v/ravenpy.svg
     :target: https://pypi.python.org/pypi/ravenpy
 
-.. image:: https://anaconda.org/conda-forge/ravenpy/badges/installer/conda.svg
+.. image:: https://anaconda.org/conda-forge/ravenpy/badges/version.svg
     :target: https://conda.anaconda.org/conda-forge
 
 .. image:: https://github.com/CSHS-CWRA/RavenPy/actions/workflows/main.yml/badge.svg

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - numpy
   - owslib >=0.24.1
   - pandas
+  - pint <0.20
   - pip
   - pre-commit
   - pydantic

--- a/ravenpy/config/rvs.py
+++ b/ravenpy/config/rvs.py
@@ -92,6 +92,19 @@ class RV(ABC):
 
     @abstractmethod
     def to_rv(self, s: str, rv_type: str) -> str:
+        """Add header to templated RV file.
+
+        Parameters
+        ----------
+        s : str
+          Templated content.
+        rv_type : str
+          RV extension.
+
+        Returns
+        -------
+        RV template with header.
+        """
         if not self._config:
             # In the case where the RV file has been created outside the context of a
             # Config object, don't include the header

--- a/ravenpy/utilities/calibration.py
+++ b/ravenpy/utilities/calibration.py
@@ -38,7 +38,7 @@ class SpotpySetup:
             self.params.append(Uniform(str(i), low=model.low[i], high=model.high[i]))
 
     def evaluation(self):
-        """In theory this method should return the trues value. Since Raven computes the objective function,
+        """In theory this method should return the true value. Since Raven computes the objective function,
         we simply return a placeholder."""
         return 1
 
@@ -53,7 +53,7 @@ class SpotpySetup:
         self.model.config.update("params", np.array(x))
 
         # Run the model
-        self.model(self.ts)
+        self.model._execute(self.ts)
         return 1
 
     def objectivefunction(self, evaluation, simulation, params=None):

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ requirements = [
     "netCDF4",
     "numpy",
     "pandas",
+    "pint<0.20",
     "pydantic",
     "requests",
     "scipy",


### PR DESCRIPTION
Spotpy calibration repeatedly calls model(), and each call, rv files are created and added to a zip file. As the zip file grows, adding new files slows down. In 0.8.0, I fixed this by skipping `merge_output` if `suppress_output` is True. This has the unintended side effect of breaking multiple tests in raven-wps and would be backward incompatible for raven-wps users, at least, without fixes to the wps handlers. 

The solution proposed here is to create another method `Raven._execute`, which runs the model but does not parse the outputs. The Spotpy calibration can use this method and avoid the slowdown problem. I've modified diagnostics so it parses output files on demand. 