### PR TITLE
Refactor HRUState so that it prints only relevant state variables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,11 +4,24 @@ History
 
 0.9.0 (unreleased)
 ------------------
+
+Breaking changes:
+
+* HRUState's signature has changed. Instead of passing variables as
+  keyword arguments (e.g. `soil0=10.`), it now expects a `state`
+  dictionary keyed by variables' Raven name (e.g. `{"SOIL[0]": 10}).
+  This change makes `rvc` files easier to read, and avoids Raven
+  warnings regarding 'initial conditions for state variables not in model'.
+
+New features:
+
 * Automatically infer scale and offset `:LinearTransform` parameters from netCDF file metadata.
 * Add support for the command `:RedirectToFile`. Tested for grid weights only.
 * Add support for the command `:WriteForcingFunctions`.
 * Add support for the command `:CustomOutput`.
 * Patch directory traversal vulnerability (`CVE-2007-4559 <(https://github.com/advisories/GHSA-gw9q-c7gh-j9vm>`_).
+
+
 
 0.8.1 (2022-10-26)
 ------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,6 +50,10 @@ RavenPy supports pre-defined Raven-emulated models:
   - HMETS
   - HBV-EC
   - MOHYSE
+  - BLENDED
+  - CANADIANSHIELD
+  - SACSMA
+  - HYPR
 
 For each one of these, `.rv` files are provided that reproduce almost perfectly the behavior of the original models and let hydrologists template typical model options. Running a simulation from an emulated model minimally requires passing a vector of model parameters and mandatory model options, as well as the list of input forcing files. RavenPy will then fill the `.rv` files with user-defined parameters and launch the simulation, for example:
 
@@ -79,15 +83,15 @@ The model configuration can be found as a zip archive in:
 
 Setting initial conditions
 --------------------------
-Each emulated model defines default initial conditions for its state variables (e.g. storage). Initial conditions can be set explicitly by passing the `HRUStateVariables` parameter when calling the model:
+Each emulated model defines default initial conditions for its state variables (e.g. storage). Initial conditions can be set explicitly by passing the `HRUState` parameter when calling the model:
 
 .. code-block:: python
 
     from ravenpy.models import GR4JCN
-    from ravenpy.models.state import HRUStateVariables
+    from ravenpy.config.commands import HRUState
 
     model = GR4JCN()
-    model(ts=ts, hru_state=HRUStateVariables(soil0=100), **kwargs)
+    model(ts=ts, hru_state=HRUState(data={"SOIL[0]": 100}), **kwargs)
 
 
 Resuming from a previous run

--- a/ravenpy/config/commands.py
+++ b/ravenpy/config/commands.py
@@ -3,6 +3,7 @@ import itertools
 import re
 from abc import ABC, abstractmethod
 from dataclasses import asdict, field
+from itertools import chain
 from pathlib import Path
 from textwrap import dedent
 from typing import Dict, Optional, Tuple, Union, no_type_check
@@ -552,157 +553,55 @@ class HRUStateVariableTableCommand(RavenCommand):
     @dataclass
     class Record(RavenCommand):
         index: int = 1
-        surface_water: float = 0
-        atmosphere: float = 0
-        atmos_precip: float = 0
-        ponded_water: float = 0
-        soil0: float = 0
-        soil1: float = 0
-        soil2: float = 0
-        soil3: float = 0
-        snow_temp: float = 0
-        snow: float = 0
-        snow_cover: float = 0
-        aet: float = 0
-        convolution0: float = 0
-        convolution1: float = 0
-        conv_stor0: float = 0
-        conv_stor1: float = 0
-        conv_stor2: float = 0
-        conv_stor3: float = 0
-        conv_stor4: float = 0
-        conv_stor5: float = 0
-        conv_stor6: float = 0
-        conv_stor7: float = 0
-        conv_stor8: float = 0
-        conv_stor9: float = 0
-        conv_stor10: float = 0
-        conv_stor11: float = 0
-        conv_stor12: float = 0
-        conv_stor13: float = 0
-        conv_stor14: float = 0
-        conv_stor15: float = 0
-        conv_stor16: float = 0
-        conv_stor17: float = 0
-        conv_stor18: float = 0
-        conv_stor19: float = 0
-        conv_stor20: float = 0
-        conv_stor21: float = 0
-        conv_stor22: float = 0
-        conv_stor23: float = 0
-        conv_stor24: float = 0
-        conv_stor25: float = 0
-        conv_stor26: float = 0
-        conv_stor27: float = 0
-        conv_stor28: float = 0
-        conv_stor29: float = 0
-        conv_stor30: float = 0
-        conv_stor31: float = 0
-        conv_stor32: float = 0
-        conv_stor33: float = 0
-        conv_stor34: float = 0
-        conv_stor35: float = 0
-        conv_stor36: float = 0
-        conv_stor37: float = 0
-        conv_stor38: float = 0
-        conv_stor39: float = 0
-        conv_stor40: float = 0
-        conv_stor41: float = 0
-        conv_stor42: float = 0
-        conv_stor43: float = 0
-        conv_stor44: float = 0
-        conv_stor45: float = 0
-        conv_stor46: float = 0
-        conv_stor47: float = 0
-        conv_stor48: float = 0
-        conv_stor49: float = 0
-        conv_stor50: float = 0
-        conv_stor51: float = 0
-        conv_stor52: float = 0
-        conv_stor53: float = 0
-        conv_stor54: float = 0
-        conv_stor55: float = 0
-        conv_stor56: float = 0
-        conv_stor57: float = 0
-        conv_stor58: float = 0
-        conv_stor59: float = 0
-        conv_stor60: float = 0
-        conv_stor61: float = 0
-        conv_stor62: float = 0
-        conv_stor63: float = 0
-        conv_stor64: float = 0
-        conv_stor65: float = 0
-        conv_stor66: float = 0
-        conv_stor67: float = 0
-        conv_stor68: float = 0
-        conv_stor69: float = 0
-        conv_stor70: float = 0
-        conv_stor71: float = 0
-        conv_stor72: float = 0
-        conv_stor73: float = 0
-        conv_stor74: float = 0
-        conv_stor75: float = 0
-        conv_stor76: float = 0
-        conv_stor77: float = 0
-        conv_stor78: float = 0
-        conv_stor79: float = 0
-        conv_stor80: float = 0
-        conv_stor81: float = 0
-        conv_stor82: float = 0
-        conv_stor83: float = 0
-        conv_stor84: float = 0
-        conv_stor85: float = 0
-        conv_stor86: float = 0
-        conv_stor87: float = 0
-        conv_stor88: float = 0
-        conv_stor89: float = 0
-        conv_stor90: float = 0
-        conv_stor91: float = 0
-        conv_stor92: float = 0
-        conv_stor93: float = 0
-        conv_stor94: float = 0
-        conv_stor95: float = 0
-        conv_stor96: float = 0
-        conv_stor97: float = 0
-        conv_stor98: float = 0
-        conv_stor99: float = 0
-        depression: float = 0
+        data: Dict[str, Union[float, str]] = field(default_factory=dict)
 
         def to_rv(self):
-            return ",".join(map(str, asdict(self).values()))
+            return ",".join(map(str, (self.index,) + tuple(self.data.values())))
 
     template = """
     :HRUStateVariableTable
-        :Attributes,SURFACE_WATER,ATMOSPHERE,ATMOS_PRECIP,PONDED_WATER,SOIL[0],SOIL[1],SOIL[2],SOIL[3],SNOW_TEMP,SNOW,SNOW_COVER,AET,CONVOLUTION[0],CONVOLUTION[1],CONV_STOR[0],CONV_STOR[1],CONV_STOR[2],CONV_STOR[3],CONV_STOR[4],CONV_STOR[5],CONV_STOR[6],CONV_STOR[7],CONV_STOR[8],CONV_STOR[9],CONV_STOR[10],CONV_STOR[11],CONV_STOR[12],CONV_STOR[13],CONV_STOR[14],CONV_STOR[15],CONV_STOR[16],CONV_STOR[17],CONV_STOR[18],CONV_STOR[19],CONV_STOR[20],CONV_STOR[21],CONV_STOR[22],CONV_STOR[23],CONV_STOR[24],CONV_STOR[25],CONV_STOR[26],CONV_STOR[27],CONV_STOR[28],CONV_STOR[29],CONV_STOR[30],CONV_STOR[31],CONV_STOR[32],CONV_STOR[33],CONV_STOR[34],CONV_STOR[35],CONV_STOR[36],CONV_STOR[37],CONV_STOR[38],CONV_STOR[39],CONV_STOR[40],CONV_STOR[41],CONV_STOR[42],CONV_STOR[43],CONV_STOR[44],CONV_STOR[45],CONV_STOR[46],CONV_STOR[47],CONV_STOR[48],CONV_STOR[49],CONV_STOR[50],CONV_STOR[51],CONV_STOR[52],CONV_STOR[53],CONV_STOR[54],CONV_STOR[55],CONV_STOR[56],CONV_STOR[57],CONV_STOR[58],CONV_STOR[59],CONV_STOR[60],CONV_STOR[61],CONV_STOR[62],CONV_STOR[63],CONV_STOR[64],CONV_STOR[65],CONV_STOR[66],CONV_STOR[67],CONV_STOR[68],CONV_STOR[69],CONV_STOR[70],CONV_STOR[71],CONV_STOR[72],CONV_STOR[73],CONV_STOR[74],CONV_STOR[75],CONV_STOR[76],CONV_STOR[77],CONV_STOR[78],CONV_STOR[79],CONV_STOR[80],CONV_STOR[81],CONV_STOR[82],CONV_STOR[83],CONV_STOR[84],CONV_STOR[85],CONV_STOR[86],CONV_STOR[87],CONV_STOR[88],CONV_STOR[89],CONV_STOR[90],CONV_STOR[91],CONV_STOR[92],CONV_STOR[93],CONV_STOR[94],CONV_STOR[95],CONV_STOR[96],CONV_STOR[97],CONV_STOR[98],CONV_STOR[99],DEPRESSION
-        :Units,mm,mm,mm,mm,mm,mm,mm,mm,C,mm,0-1,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm
-        {hru_states}
+        :Attributes,{names}
+        {values}
     :EndHRUStateVariableTable
     """
+
     hru_states: Dict[int, Record] = field(default_factory=dict)
 
     @classmethod
     def parse(cls, sol):
         pat = r"""
         :HRUStateVariableTable
-        \s*:Attributes.*?
+        \s*:Attributes,(.+)
         \s*:Units.*?
         (.+)
         :EndHRUStateVariableTable
         """
         m = re.search(dedent(pat).strip(), sol, re.DOTALL)
-        lines = m.group(1).strip().splitlines()  # type: ignore
+        names = m.group(1).strip().split(",")
+        lines = m.group(2).strip().splitlines()  # type: ignore
         lines = [re.split(r",|\s+", line.strip()) for line in lines]
         hru_states = {}
         for line in lines:
             idx, *values = line
             idx = int(idx)
             values = list(map(float, values))
-            hru_states[idx] = cls.Record(*([idx] + values))
+            hru_states[idx] = cls.Record(index=idx, data=dict(zip(names, values)))
         return cls(hru_states)
 
     def to_rv(self):
+        names = sorted(
+            list(set(chain(*[tuple(s.data.keys()) for s in self.hru_states.values()])))
+        )
+        values = [
+            [
+                s.index,
+            ]
+            + [s.data.get(n, 0.0) for n in names]
+            for s in self.hru_states.values()
+        ]
         return dedent(self.template).format(
-            hru_states="\n    ".join(map(str, self.hru_states.values()))
+            names=",".join(names),
+            values="\n    ".join([",".join(map(str, v)) for v in values]),
         )
 
 

--- a/ravenpy/models/emulators/blended.py
+++ b/ravenpy/models/emulators/blended.py
@@ -284,7 +284,7 @@ class BLENDED(Raven):
 
         topsoil_hlf = params.par_x29 * 0.5 * 1000
         phreatic_hlf = params.par_x30 * 0.5 * 1000
-        hru_state = HRUState(soil0=topsoil_hlf, soil1=phreatic_hlf)
+        hru_state = HRUState(data={"SOIL[0]": topsoil_hlf, "SOIL[1]": phreatic_hlf})
         self.config.rvc.set_hru_state(hru_state)
 
         self.config.rvt.rain_correction = params.par_x33

--- a/ravenpy/models/emulators/canadianshield.py
+++ b/ravenpy/models/emulators/canadianshield.py
@@ -278,10 +278,14 @@ class CANADIANSHIELD(Raven):
         soil1 = params.par_x02 * 1000.0 * 0.5
         soil2 = params.par_x03 * 1000.0 * 0.5
         self.config.rvc.set_hru_state(
-            HRUState(index=1, soil0=soil0, soil1=soil1, soil2=soil2)
+            HRUState(
+                index=1, data={"SOIL[0]": soil0, "SOIL[1]": soil1, "SOIL[2]": soil2}
+            )
         )
         self.config.rvc.set_hru_state(
-            HRUState(index=2, soil0=soil0, soil1=0, soil2=soil2)
+            HRUState(
+                index=2, data={"SOIL[0]": soil0, "SOIL[1]": soil1, "SOIL[2]": soil2}
+            )
         )
 
         self.config.rvt.rain_correction = params.par_x32
@@ -583,11 +587,24 @@ class CANADIANSHIELD_OST(Ostrich, CANADIANSHIELD):
         self.config.rvh.hrus[0].area = "par_area_organic_SB1"  # type: ignore
         self.config.rvh.hrus[1].area = "par_area_bedrock_SB1"  # type: ignore
 
-        self.config.rvc.set_hru_state(HRUState(index=1))
-        self.config.rvc.hru_states[1].soil0 = "par_half_x01"  # type: ignore
-        self.config.rvc.hru_states[1].soil1 = "par_half_x02"  # type: ignore
-        self.config.rvc.hru_states[1].soil2 = "par_half_x03"  # type: ignore
-
-        self.config.rvc.set_hru_state(HRUState(index=2))
+        self.config.rvc.set_hru_state(
+            HRUState(
+                index=1,
+                data={
+                    "SOIL[0]": "par_half_x01",
+                    "SOIL[1]": "par_half_x02",
+                    "SOIL[2]": "par_half_x03",
+                },
+            )
+        )
+        self.config.rvc.set_hru_state(
+            HRUState(
+                index=2,
+                data={
+                    "SOIL[0]": "par_half_x01",
+                    "SOIL[2]": "par_half_x03",
+                },
+            )
+        )
         self.config.rvc.hru_states[2].soil0 = "par_half_x01"  # type: ignore
         self.config.rvc.hru_states[2].soil2 = "par_half_x03"  # type: ignore

--- a/ravenpy/models/emulators/gr4jcn.py
+++ b/ravenpy/models/emulators/gr4jcn.py
@@ -203,7 +203,7 @@ class GR4JCN(Raven):
             for hru in self.config.rvh.hrus:
                 if isinstance(hru, GR4JCN.LandHRU) or hru.hru_type == "land":
                     self.config.rvc.hru_states[hru.hru_id] = HRUState(
-                        index=hru.hru_id, soil0=soil0, soil1=soil1
+                        index=hru.hru_id, data={"SOIL[0]": soil0, "SOIL[1]": soil1}
                     )
                 elif isinstance(hru, GR4JCN.LakeHRU) or hru.hru_type == "lake":
                     self.config.rvc.hru_states[hru.hru_id] = HRUState(index=hru.hru_id)

--- a/ravenpy/models/emulators/hbvec.py
+++ b/ravenpy/models/emulators/hbvec.py
@@ -266,7 +266,7 @@ class HBVEC(Raven):
         # Default initial conditions if none are given
         if not self.config.rvc.hru_states:
             soil2 = 0.50657
-            self.config.rvc.hru_states[1] = HRUState(soil2=soil2)
+            self.config.rvc.hru_states[1] = HRUState(data={"SOIL[2]": soil2})
 
         if not self.config.rvc.basin_states:
             self.config.rvc.basin_states[1] = BasinIndexCommand()

--- a/ravenpy/models/emulators/hmets.py
+++ b/ravenpy/models/emulators/hmets.py
@@ -204,7 +204,9 @@ class HMETS(Raven):
         if not self.config.rvc.hru_states:
             soil0 = params.TOPSOIL * 0.5
             soil1 = params.PHREATIC * 0.5
-            self.config.rvc.hru_states[1] = HRUState(soil0=soil0, soil1=soil1)
+            self.config.rvc.hru_states[1] = HRUState(
+                data={"SOIL[0]": soil0, "SOIL[1]": soil1}
+            )
 
 
 class HMETS_OST(Ostrich, HMETS):

--- a/ravenpy/models/emulators/hypr.py
+++ b/ravenpy/models/emulators/hypr.py
@@ -266,7 +266,9 @@ class HYPR(Raven):
         # R V C #
         #########
 
-        self.config.rvc.hru_states[1] = HRUState(soil0=10, soil1=10, depression=20)
+        self.config.rvc.hru_states[1] = HRUState(
+            data={"SOIL[0]": 10, "SOIL[1]": 10, "DEPRESSION": 20}
+        )
 
     def derived_parameters(self):
         params = cast(HYPR.Params, self.config.rvp.params)

--- a/ravenpy/models/emulators/sacsma.py
+++ b/ravenpy/models/emulators/sacsma.py
@@ -275,7 +275,9 @@ class SACSMA(Raven):
 
         soil0 = params.par_x04 * 1000.0
         soil2 = params.par_x06 * 1000.0
-        self.config.rvc.hru_states[1] = HRUState(soil0=soil0, soil2=soil2)
+        self.config.rvc.hru_states[1] = HRUState(
+            data={"SOIL[0]": soil0, "SOIL[2]": soil2}
+        )
 
         self.config.rvt.rain_correction = params.par_x20
         self.config.rvt.snow_correction = params.par_x21

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,37 @@
+from textwrap import dedent
+
+from ravenpy.config.commands import HRUState, HRUStateVariableTableCommand
+
+
+def test_hru_state():
+    s = HRUState(index=1, data={"SOIL[0]": 1, "SOIL[1]": 2.0})
+    assert s.to_rv() == "1,1.0,2.0"
+
+
+class TestHRUStateVariableTableCommand:
+    def test_to_rv(self):
+        s1 = HRUState(index=1, data={"SOIL[0]": 0.1, "SOIL[1]": 1.0})
+        s2 = HRUState(index=2, data={"SOIL[3]": 3, "SOIL[2]": 2.0})
+        t = HRUStateVariableTableCommand(hru_states={1: s1, 2: s2})
+        assert dedent(t.to_rv()) == dedent(
+            """
+            :HRUStateVariableTable
+                :Attributes,SOIL[0],SOIL[1],SOIL[2],SOIL[3]
+                1,0.1,1.0,0.0,0.0
+                2,0.0,0.0,2.0,3.0
+            :EndHRUStateVariableTable
+            """
+        )
+
+    def test_parse(self):
+        solution = """
+:HRUStateVariableTable
+  :Attributes,SURFACE_WATER,ATMOSPHERE,ATMOS_PRECIP,PONDED_WATER,SOIL[0],SOIL[1],SNOW,SNOW_LIQ,CUM_SNOWMELT,CONVOLUTION[0],CONVOLUTION[1],AET,CONV_STOR[0],CONV_STOR[1],CONV_STOR[2],CONV_STOR[3],CONV_STOR[4],CONV_STOR[5],CONV_STOR[6],CONV_STOR[7],CONV_STOR[8],CONV_STOR[9],CONV_STOR[10],CONV_STOR[11],CONV_STOR[12],CONV_STOR[13],CONV_STOR[14],CONV_STOR[15],CONV_STOR[16],CONV_STOR[17],CONV_STOR[18],CONV_STOR[19],CONV_STOR[20],CONV_STOR[21],CONV_STOR[22],CONV_STOR[23],CONV_STOR[24],CONV_STOR[25],CONV_STOR[26],CONV_STOR[27],CONV_STOR[28],CONV_STOR[29],CONV_STOR[30],CONV_STOR[31],CONV_STOR[32],CONV_STOR[33],CONV_STOR[34],CONV_STOR[35],CONV_STOR[36],CONV_STOR[37],CONV_STOR[38],CONV_STOR[39],CONV_STOR[40],CONV_STOR[41],CONV_STOR[42],CONV_STOR[43],CONV_STOR[44],CONV_STOR[45],CONV_STOR[46],CONV_STOR[47],CONV_STOR[48],CONV_STOR[49],CONV_STOR[50],CONV_STOR[51],CONV_STOR[52],CONV_STOR[53],CONV_STOR[54],CONV_STOR[55],CONV_STOR[56],CONV_STOR[57],CONV_STOR[58],CONV_STOR[59],CONV_STOR[60],CONV_STOR[61],CONV_STOR[62],CONV_STOR[63],CONV_STOR[64],CONV_STOR[65],CONV_STOR[66],CONV_STOR[67],CONV_STOR[68],CONV_STOR[69],CONV_STOR[70],CONV_STOR[71],CONV_STOR[72],CONV_STOR[73],CONV_STOR[74],CONV_STOR[75],CONV_STOR[76],CONV_STOR[77],CONV_STOR[78],CONV_STOR[79],CONV_STOR[80],CONV_STOR[81],CONV_STOR[82],CONV_STOR[83],CONV_STOR[84],CONV_STOR[85],CONV_STOR[86],CONV_STOR[87],CONV_STOR[88],CONV_STOR[89],CONV_STOR[90],CONV_STOR[91],CONV_STOR[92],CONV_STOR[93],CONV_STOR[94],CONV_STOR[95],CONV_STOR[96],CONV_STOR[97],CONV_STOR[98],CONV_STOR[99]
+  :Units,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm,mm
+  1,0.00000,0.00000,-0.16005,0.00000,144.54883,455.15708,0.16005,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000,0.00000
+:EndHRUStateVariableTable
+        """
+        sv = HRUStateVariableTableCommand.parse(solution)
+        assert len(sv.hru_states) == 1
+        assert sv.hru_states[1].index == 1
+        assert sv.hru_states[1].data["ATMOS_PRECIP"] == -0.16005

--- a/tests/test_data_assimilation.py
+++ b/tests/test_data_assimilation.py
@@ -67,7 +67,7 @@ class TestAssimilationGR4JCN:
             raise ValueError("Assimilation requires perturbing the flow variable.")
 
         # Assimilation variables (from HRUStateVariable)
-        assim_var = ("soil0", "soil1")
+        assim_var = ("SOIL[0]", "SOIL[1]")
 
         # Assimilation period (days between each assimilation step)
         assim_step_days = 3

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -565,7 +565,9 @@ class TestGR4JCN:
 
         np.testing.assert_almost_equal(d["DIAG_NASH_SUTCLIFFE"], -0.117315, 4)
 
-        model.config.rvc.hru_states[1] = HRUStateVariableTableCommand.Record(soil0=0)
+        model.config.rvc.hru_states[1] = HRUStateVariableTableCommand.Record(
+            index=1, data={"SOIL[0]": 0}
+        )
 
         # Set initial conditions explicitly
         model(
@@ -701,9 +703,7 @@ class TestGR4JCN:
         s_1 = float(model.storage["Soil Water[1]"].isel(time=-1).values)
 
         # hru_state = replace(model.rvc.hru_state, soil0=s_0, soil1=s_1)
-        model.config.rvc.hru_states[1] = replace(
-            model.config.rvc.hru_states[1], soil0=s_0, soil1=s_1
-        )
+        model.config.rvc.hru_states[1].data.update({"SOIL[0]": s_0, "SOIL[1]": s_1})
 
         model(
             TS,

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -93,8 +93,8 @@ class TestRVC:
 
     def test_parse(self):
         assert len(self.rvc.hru_states) == 1
-        assert self.rvc.hru_states[1].atmosphere == 821.98274
-        assert self.rvc.hru_states[1].atmos_precip == -1233.16
+        assert self.rvc.hru_states[1].data["ATMOSPHERE"] == 821.98274
+        assert self.rvc.hru_states[1].data["ATMOS_PRECIP"] == -1233.16
 
         assert len(self.rvc.basin_states) == 1
         assert self.rvc.basin_states[1].channel_storage == 0


### PR DESCRIPTION
**This is a breaking change.** 

Change the signature of HRUState. 
Instead of `HRUState(soil0=10)`, we now write `HRUState(data={"SOIL[0]": 10})`. 

Knowing which variables are specified, we're able to only put those in the rvc. This avoids warnings of `initial conditions for state variables not in model`. I think it's also a better design become the variable names are identical to those in the RavenC documentation. 