### PR TITLE
Support distinct netcdf indices for meteo and hydrometric stations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,9 @@ Breaking changes:
   dictionary keyed by variables' Raven name (e.g. `{"SOIL[0]": 10}).
   This change makes `rvc` files easier to read, and avoids Raven
   warnings regarding 'initial conditions for state variables not in model'.
-* `nc_index` renamed to `meteo_idx` to enable the specification of distinct indices for observed streamflow using `hydro_idx`.
+* `nc_index` renamed to `meteo_idx` to enable the specification of distinct
+  indices for observed streamflow using `hydro_idx`. `nc_index` remains
+  supported for backward compatibility.
 
 New features:
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,11 +12,13 @@ Breaking changes:
   dictionary keyed by variables' Raven name (e.g. `{"SOIL[0]": 10}).
   This change makes `rvc` files easier to read, and avoids Raven
   warnings regarding 'initial conditions for state variables not in model'.
-
+* `nc_index` renamed to `meteo_idx` to enable the specification of distinct indices for observed streamflow using `hydro_idx`.
 
 New features:
 
-* Automatically infer scale and offset `:LinearTransform` parameters from netCDF file metadata.
+* Add support for hydrometric gauge data distinct from meteorological input data. Configuration parameter `hydro_idx` identifies the gauge station index, while `meteo_idx` (previously `nc_index`) stands for the meteo station index.
+* Add support for multiple gauge observations. If a list of `hydro_idx` is provided, it must be accompanied with a list of corresponding subbasin identifiers (`gauged_sb_ids`) of the same length.
+* Automatically infer scale and offset `:LinearTransform` parameters from netCDF file metadata, so that input data units are automatically converted to Raven-compliant units whenever possible.
 * Add support for the command `:RedirectToFile`. Tested for grid weights only.
 * Add support for the command `:WriteForcingFunctions`.
 * Add support for the command `:CustomOutput`.

--- a/docs/notebooks/Running_Raven_with_CANOPEX_data.ipynb
+++ b/docs/notebooks/Running_Raven_with_CANOPEX_data.ipynb
@@ -646,7 +646,7 @@
     "config = dict(\n",
     "    start_date=dt.datetime(2010, 6, 1),\n",
     "    end_date=dt.datetime(2010, 9, 1),\n",
-    "    nc_index=i,\n",
+    "    meteo_idx=i,\n",
     "    run_name=\"Test_run\",\n",
     "    rain_snow_fraction=\"RAINSNOW_DINGMAN\",\n",
     "    tasmax={\"offset\": -273.15},\n",

--- a/ravenpy/config/rvs.py
+++ b/ravenpy/config/rvs.py
@@ -632,7 +632,7 @@ class RVT(RV):
         # Specifies whether the variables must be configured using file NC data
         self._auto_nc_configure = True
 
-        self.nc_index = self.station_idx = 0  # For meteo forcing files
+        self.nc_index = self.meteo_idx = 0  # For meteo forcing files
 
         self.hydro_idx: Tuple = (0,)  # Streamflow observation file station index
         self.gauged_sb_ids: Tuple = (
@@ -760,6 +760,9 @@ class RVT(RV):
         if key in self._var_specs:
             self._var_specs[key].update(value)
             return True
+        # For backward compatibility
+        if key == "nc_index":
+            key = "meteo_idx"
         return super().update(key, value)
 
     def to_rv(self):
@@ -778,7 +781,7 @@ class RVT(RV):
         use_gauge = any(type(cmd) is DataCommand for cmd in self._var_cmds.values())
         if use_gauge:
             gauges = []
-            for idx in np.atleast_1d(self.nc_index):
+            for idx in np.atleast_1d(self.meteo_idx):
                 data_cmds = []
                 for var, cmd in self._var_cmds.items():
                     if cmd and not isinstance(cmd, ObservationDataCommand):
@@ -838,9 +841,7 @@ class RVT(RV):
             d["gauge"] = "\n".join([str(g) for g in gauges])
         else:
             # Construct default grid weights applying equally to all HRUs
-            data = [
-                (hru.hru_id, self.station_idx, 1.0) for hru in self._config.rvh.hrus
-            ]
+            data = [(hru.hru_id, self.meteo_idx, 1.0) for hru in self._config.rvh.hrus]
             gw = self.grid_weights or GridWeightsCommand(
                 number_hrus=len(data),
                 number_grid_cells=self._number_grid_cells,

--- a/ravenpy/config/rvs.py
+++ b/ravenpy/config/rvs.py
@@ -632,7 +632,13 @@ class RVT(RV):
         # Specifies whether the variables must be configured using file NC data
         self._auto_nc_configure = True
 
-        self.nc_index = 0
+        self.nc_index = self.station_idx = 0  # For meteo forcing files
+
+        self.hydro_idx: Tuple = (0,)  # Streamflow observation file station index
+        self.gauged_sb_ids: Tuple = (
+            None,
+        )  # Corresponding sub-basin ID. If (None,), will try to guess.
+
         self.grid_weights: Union[GridWeightsCommand, RedirectToFileCommand, None] = None
         self.rain_correction = None
         self.snow_correction = None
@@ -812,7 +818,7 @@ class RVT(RV):
                     and self._station_id.shape
                     and len(self._station_id) > idx
                 ):
-                    name = self._station_id[idx]
+                    name = str(self._station_id.values[idx])
                 else:
                     name = f"default_{idx + 1}"
 
@@ -832,7 +838,9 @@ class RVT(RV):
             d["gauge"] = "\n".join([str(g) for g in gauges])
         else:
             # Construct default grid weights applying equally to all HRUs
-            data = [(hru.hru_id, self.nc_index, 1.0) for hru in self._config.rvh.hrus]
+            data = [
+                (hru.hru_id, self.station_idx, 1.0) for hru in self._config.rvh.hrus
+            ]
             gw = self.grid_weights or GridWeightsCommand(
                 number_hrus=len(data),
                 number_grid_cells=self._number_grid_cells,
@@ -847,24 +855,32 @@ class RVT(RV):
                     cmds.append(cmd)
             d["forcing_list"] = "\n".join(map(str, cmds))
 
-        # QUESTION: is it possible to have (and if yes should we support) more than 1
-        # observation variable? For now we don't.
         for cmd in self._var_cmds.values():
+            observed_data = []
             if isinstance(cmd, ObservationDataCommand) and self._config is not None:
-                # Search for the gauged SB, not sure what should happen when there are
-                # more than one (should it be even supported?)
-                for sb in self._config.rvh.subbasins:
-                    if sb.gauged:
-                        cmd.subbasin_id = sb.subbasin_id
-                        break
-                else:
-                    raise Exception(
-                        "Could not find an outlet subbasin for observation data"
+                if self.gauged_sb_ids == (None,):
+                    # Search for single gauged sub-basin
+                    for sb in self._config.rvh.subbasins:
+                        if sb.gauged:
+                            self.gauged_sb_ids = (sb.subbasin_id,)
+                            break
+                    else:
+                        raise Exception(
+                            "Could not find an outlet subbasin for observation data"
+                        )
+
+                if len(self.gauged_sb_ids) != len(self.hydro_idx):
+                    raise ValueError(
+                        "`gauged_sb_ids` and `hydro_idx` must have the same number of entries."
                     )
-                # Set the :StationxIdx (which starts at 1)
-                cmd.index = self.nc_index + 1
-                d["observed_data"] = cmd  # type: ignore
-                break
+
+                for idx, sb_id in zip(self.hydro_idx, self.gauged_sb_ids):
+                    cmd = deepcopy(cast(ObservationDataCommand, cmd))
+                    cmd.index = idx + 1  # Python index to Raven index
+                    cmd.subbasin_id = sb_id
+                    observed_data.append(cmd)
+
+                d["observed_data"] = "\n".join(map(str, observed_data))  # type: ignore
 
         return super().to_rv(dedent(self.tmpl.lstrip("\n")).format(**d), "RVT")
 

--- a/ravenpy/models/base.py
+++ b/ravenpy/models/base.py
@@ -328,7 +328,7 @@ class Raven:
             self._pdim = "params"
         elif "hru_state" in parallel.keys() or "basin_state" in parallel.keys():
             self._pdim = "state"
-        elif "nc_index" in parallel.keys():
+        elif "meteo_idx" in parallel.keys() or "nc_index" in parallel.keys():
             self._pdim = "nbasins"
         else:
             self._pdim = "pdim"

--- a/ravenpy/utilities/data_assimilation.py
+++ b/ravenpy/utilities/data_assimilation.py
@@ -73,7 +73,7 @@ def assimilate(
     model(
         ts,
         parallel=dict(
-            hru_state=hru_states, basin_state=basin_states, nc_index=range(n_members)
+            hru_state=hru_states, basin_state=basin_states, meteo_idx=range(n_members)
         ),
     )
 

--- a/tests/test_ECCC_forecast.py
+++ b/tests/test_ECCC_forecast.py
@@ -56,7 +56,7 @@ class TestECCCForecast:
             overwrite=True,
             pr={"time_shift": -0.25, "deaccumulate": True},
             tas={"time_shift": -0.25},
-            parallel=dict(nc_index=range(nm)),
+            parallel=dict(meteo_idx=range(nm)),
         )
 
         # The model now has the forecast data generated and it has 10 days of forecasts.

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -778,7 +778,7 @@ class TestGR4JCN:
         model.config.rvi.start_date = dt.datetime(2000, 1, 1)
         model.config.rvi.end_date = dt.datetime(2002, 1, 1)
         model.config.update(params=(0.529, -3.396, 407.29, 1.072, 16.9, 0.947))
-        model.config.rvt.nc_index = [0, 1, 2]
+        model.config.rvt.meteo_idx = [0, 1, 2]
         model.config.rvt.hydro_idx = (1,)
         model(
             ts=[
@@ -814,7 +814,7 @@ class TestGR4JCN:
         config = dict(
             start_date=dt.datetime(2010, 6, 1),
             end_date=dt.datetime(2010, 6, 10),
-            nc_index=5600,
+            meteo_idx=5600,
             run_name="Test_run",
             rain_snow_fraction="RAINSNOW_DINGMAN",
             hrus=[

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -770,6 +770,22 @@ class TestGR4JCN:
         z = zipfile.ZipFile(model.outputs["rv_config"])
         assert len(z.filelist) == 10
 
+    def test_multiple_gauge_stations(self):
+        ts = get_local_testdata("famine/famine_input.nc")
+
+        model = GR4JCN()
+        model.config.rvh.hrus = (GR4JCN.LandHRU(**salmon_land_hru_1),)
+        model.config.rvi.start_date = dt.datetime(2000, 1, 1)
+        model.config.rvi.end_date = dt.datetime(2002, 1, 1)
+        model.config.update(params=(0.529, -3.396, 407.29, 1.072, 16.9, 0.947))
+        model.config.rvt.nc_index = [0, 1, 2]
+        model.config.rvt.hydro_idx = (1,)
+        model(
+            ts=[
+                ts,
+            ]
+        )
+
     @pytest.mark.online
     def test_dap(self):
         """Test Raven with DAP link instead of local netCDF file."""

--- a/tests/test_hindcasting.py
+++ b/tests/test_hindcasting.py
@@ -61,7 +61,7 @@ class TestHindcasting:
                 "deaccumulate": True,
             },
             tas={"time_shift": -0.25},
-            parallel=dict(nc_index=range(nm)),
+            parallel=dict(meteo_idx=range(nm)),
         )
 
         # The model now has the forecast data generated and it has 10 days of forecasts.

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -186,7 +186,7 @@ class TestRVT:
 
     def test_gauges(self):
         rvt = RVT(config=None)
-        rvt.nc_index = [0, 1, 2]
+        rvt.meteo_idx = [0, 1, 2]
         rvt.configure_from_nc_data([get_local_testdata("famine/famine_input.nc")])
         out = rvt.to_rv()
         assert len(re.findall(":Gauge", out)) == 3


### PR DESCRIPTION
Closes #228

- Allows configuration to use distinct files and indices for hydro and meteo data. 
- Adds support for multiple hydro gauge stations. To use, configuration needs to include a new config parameter called `gauged_sb_ids`, a sequence identifying the subbasin draining at the gauge station.
- Renames configuration parameter `nc_index` to `meteo_idx` to reduce confusion between the two indices. `nc_index` should still work but is considered deprecated and will be removed in a future version. 
 