### PR TITLE
Manifest updates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ include requirements_dev.txt
 include requirements_docs.txt
 include requirements_gis.txt
 
-recursive-include ravenpy *
+recursive-include ravenpy *.py *.zip *.csv *.rst
 recursive-include tests *
 recursive-include benchmark *.ipynb *.txt
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif *.ipynb

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,16 +19,16 @@ replace = "version": "{new_version}",
 test = pytest
 
 [tool:pytest]
-collect_ignore = 
+collect_ignore =
 	setup.py
-addopts = 
+addopts =
 	--color=yes
 	--verbose
 	--numprocesses=auto
 	--maxprocesses=6
 python_files = test_*.py
 norecursedirs = src .git bin
-filterwarnings = 
+filterwarnings =
 	ignore::UserWarning
 
 [isort]
@@ -41,7 +41,7 @@ relative_files = True
 omit = tests/*
 
 [flake8]
-exclude = 
+exclude =
 	.git,
 	docs,
 	build,
@@ -56,7 +56,7 @@ exclude =
 	.txt,
 max-line-length = 88
 max-complexity = 12
-ignore = 
+ignore =
 	C901
 	E203
 	E231
@@ -66,9 +66,9 @@ ignore =
 	F403
 	W503
 	W504
-per-file-ignores = 
+per-file-ignores =
 	tests/*:E402
-rst-roles = 
+rst-roles =
 	mod,
 	py:attr,
 	py:attribute,

--- a/setup.py
+++ b/setup.py
@@ -259,6 +259,7 @@ setup(
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/x-rst",
     include_package_data=True,
+    package_data={"ravenpy": ["*.csv", "*.zip"]},
     keywords="ravenpy",
     name="ravenpy",
     packages=find_packages(


### PR DESCRIPTION
This adds more clarity as to which files within RavenPy are listed as `data`. This should reduce build warnings on conda-forge when building packages, i.e. muting the following messages:
```
writing manifest file 'ravenpy.egg-info/SOURCES.txt'
  /home/conda/feedstock_root/build_artifacts/ravenpy_1671727208024/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/lib/python3.11/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'ravenpy.data.hydrobasins_domains' as data is deprecated, please list it in `packages`.
      !!


      ############################
      # Package would be ignored #
      ############################
      Python recognizes 'ravenpy.data.hydrobasins_domains' as an importable package,
      but it is not listed in the `packages` configuration of setuptools.

      'ravenpy.data.hydrobasins_domains' has been automatically added to the distribution only
      because it may contain data files, but this behavior is likely to change
      in future versions of setuptools (and therefore is considered deprecated).

      Please make sure that 'ravenpy.data.hydrobasins_domains' is included as a package by using
      the `packages` configuration field or the proper discovery methods
      (for example by using `find_namespace_packages(...)`/`find_namespace:`
      instead of `find_packages(...)`/`find:`).

      You can read more about "package discovery" and "data files" on setuptools
      documentation page.


  !!

    check.warn(importable)
  /home/conda/feedstock_root/build_artifacts/ravenpy_1671727208024/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/lib/python3.11/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'ravenpy.data.regionalisation' as data is deprecated, please list it in `packages`.
      !!


      ############################
      # Package would be ignored #
      ############################
      Python recognizes 'ravenpy.data.regionalisation' as an importable package,
      but it is not listed in the `packages` configuration of setuptools.

      'ravenpy.data.regionalisation' has been automatically added to the distribution only
      because it may contain data files, but this behavior is likely to change
      in future versions of setuptools (and therefore is considered deprecated).

      Please make sure that 'ravenpy.data.regionalisation' is included as a package by using
      the `packages` configuration field or the proper discovery methods
      (for example by using `find_namespace_packages(...)`/`find_namespace:`
      instead of `find_packages(...)`/`find:`).

      You can read more about "package discovery" and "data files" on setuptools
      documentation page.


  !!
```