### PR TITLE
Use raven-hydro v3.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - raven-hydro ==3.5
+  - raven-hydro ==3.6
   - ostrich ==21.03.16  # Not available on Windows
   - python >=3.8
   - affine

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -740,10 +740,10 @@ class TestGR4JCN:
 
     def test_version(self):
         model = Raven()
-        assert model.raven_version == "3.5"
+        assert model.raven_version == "3.6"
 
         model = GR4JCN()
-        assert model.raven_version == "3.5"
+        assert model.raven_version == "3.6"
 
     def test_parallel_params(self, get_file):
         ts = get_file(salmon_river)

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
     # Pin @v1.6.0 needed due to issue with PyPI wheels (see: https://github.com/Unidata/netcdf4-python/issues/1192)
     python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir netcdf4==1.6.2 --no-binary netcdf4
     # Deal with some GDAL silliness
-    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir --use-pep517 GDAL=={env:GDAL_VERSION}
+    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir GDAL=={env:GDAL_VERSION} --global-option=build_ext --global-option="-I/usr/include/gdal"
     # Pin @ <v65.6 due to incompatibility with numpy (see: https://github.com/numpy/numpy/issues/22623)
     python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir setuptools<65.6
     # Install the Raven and Ostrich binaries

--- a/tox.ini
+++ b/tox.ini
@@ -39,11 +39,11 @@ commands =
     numpy: python -m pip install --upgrade --force-reinstall --no-cache-dir numpy==1.23 numba
     # Install NetCDF4-Python via source files
     # Pin @v1.6.0 needed due to issue with PyPI wheels (see: https://github.com/Unidata/netcdf4-python/issues/1192)
-    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir netcdf4==1.6.0 --no-binary netcdf4
+    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir netcdf4==1.6.2 --no-binary netcdf4
     # Deal with some GDAL silliness
-    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir GDAL=={env:GDAL_VERSION} --global-option=build_ext --global-option="-I/usr/include/gdal"
+    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir --use-pep517 GDAL=={env:GDAL_VERSION}
     # Pin @ <v65.6 due to incompatibility with numpy (see: https://github.com/numpy/numpy/issues/22623)
-    python -m pip install --upgrade --force-reinstall --no-cache-dir setuptools<65.6
+    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir setuptools<65.6
     # Install the Raven and Ostrich binaries
     python -m pip install --no-user --verbose --no-deps --no-cache-dir . --install-option="--with-binaries"
     # Run tests


### PR DESCRIPTION
### Changes

* Use RavenC version 3.6

I needed to add some handling to patch the makefile to remove some compiler options. I would like us to remove this handling once we drop Ostrich and implement a Raven CLI command to perform the RavenC build step.

Changes in `setuptools` are gradually rendering all of our special handling obsolete. Ideally, we should consider dropping `setup.py` and `cmdclass` functionality altogether in a version not too far off.