### PR TITLE
Maintain Python3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,8 @@ jobs:
           environment-file: environment.yml
           extra-specs: |
             mamba
-            python="3.9"
+            pip<23.1
+            python=3.9
       - name: Conda and Mamba versions
         run: |
           mamba --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - tox-env: py39-numpy
+          - tox-env: py38
             python-version: "3.8"
           - tox-env: py39-numpy
             python-version: "3.9"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
       matrix:
         include:
           - tox-env: py39-numpy
+            python-version: "3.8"
+          - tox-env: py39-numpy
             python-version: "3.9"
           - tox-env: py310
             python-version: "3.10"

--- a/ravenpy/config/commands.py
+++ b/ravenpy/config/commands.py
@@ -629,9 +629,9 @@ class Gauge(FlatCommand):
         alt_names: Optional[Dict[str, str]] = None,
         mon_ave: bool = False,
         data_kwds: Optional[
-            dict[
+            Dict[
                 str,
-                Union[dict[str, Union[bool, dict[str, int], float]], dict[str, Any]],
+                Union[Dict[str, Union[bool, Dict[str, int], float]], Dict[str, Any]],
             ]
         ] = None,
         **kwds,

--- a/ravenpy/extractors/forecasts.py
+++ b/ravenpy/extractors/forecasts.py
@@ -1,13 +1,21 @@
 import datetime as dt
 import logging
 import re
+from pathlib import Path
 from typing import Any, List, Tuple, Union
 
-import fiona
 import pandas as pd
 import xarray as xr
 from pandas import DatetimeIndex, Series, Timestamp
 from xarray import Dataset
+
+from . import gis_import_error_message
+
+try:
+    import fiona
+except (ImportError, ModuleNotFoundError) as e:
+    msg = gis_import_error_message.format(Path(__file__).stem)
+    raise ImportError(msg) from e
 
 LOGGER = logging.getLogger("PYWPS")
 
@@ -32,7 +40,7 @@ def get_hindcast_day(region_coll: fiona.Collection, date, climate_model="GEPS"):
 def get_CASPAR_dataset(
     climate_model: str, date: dt.datetime
 ) -> Tuple[
-    xr.Dataset, list[Union[Union[DatetimeIndex, Series, Timestamp, Timestamp], Any]]
+    xr.Dataset, List[Union[Union[DatetimeIndex, Series, Timestamp, Timestamp], Any]]
 ]:
     """Return CASPAR dataset."""
 
@@ -58,8 +66,8 @@ def get_CASPAR_dataset(
 
 def get_ECCC_dataset(
     climate_model: str,
-) -> tuple[
-    Dataset, list[Union[Union[DatetimeIndex, Series, Timestamp, Timestamp], Any]]
+) -> Tuple[
+    Dataset, List[Union[Union[DatetimeIndex, Series, Timestamp, Timestamp], Any]]
 ]:
     """Return latest GEPS forecast dataset."""
     if climate_model == "GEPS":

--- a/ravenpy/utilities/forecasting.py
+++ b/ravenpy/utilities/forecasting.py
@@ -306,6 +306,7 @@ def _shift_esp_time(nc, year, dim="member"):
     )
 
     # Write to disk
+    # FIXME: pathlib.Path().with_stem() was introduced in Python3.9
     fn = nc.with_stem(nc.stem + "_shifted")
     out.to_netcdf(fn, mode="w")
     return fn

--- a/ravenpy/utilities/forecasting.py
+++ b/ravenpy/utilities/forecasting.py
@@ -306,8 +306,7 @@ def _shift_esp_time(nc, year, dim="member"):
     )
 
     # Write to disk
-    # FIXME: pathlib.Path().with_stem() was introduced in Python3.9
-    fn = nc.with_stem(nc.stem + "_shifted")
+    fn = nc.parent.joinpath(f"{nc.stem}_shifted{nc.suffix}")
     out.to_netcdf(fn, mode="w")
     return fn
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip
+pip>=21.0,<23.1
 bump2version
 wheel
 watchdog
@@ -13,7 +13,7 @@ pytest
 pytest-cov
 pytest-xdist>=3.2.0
 filelock
-black>=23.1.0
+black>=23.3.0
 isort
 pre-commit
 holoviews

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ filterwarnings =
 
 [isort]
 profile = black
-py_version = 39
+py_version = 38
 append_only = true
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -239,7 +239,7 @@ def create_external_deps_install_class(command_cls):
 setup(
     author="David Huard",
     author_email="huard.david@ouranos.ca",
-    python_requires=">=3.9",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -248,6 +248,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.0
 envlist = black, py{38,39,310}-numpy, docs
 requires =
-    pip >=21.0,<23.0
+    pip >=21.0,<23.1
     setuptools >=63.0,<65.6
 opts = --verbose
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 min_version = 4.0
-envlist = black, py{39,310}-numpy, docs
+envlist = black, py{38,39,310}-numpy, docs
 requires =
-    pip >= 21.0
+    pip >=21.0,<23.0
     setuptools >=63.0,<65.6
 opts = --verbose
 


### PR DESCRIPTION
## Changes

* Reinstates that Python3.8 is supported, adjust static types
* Re-adds Python3.8 to workflows
* Fixes a potential error that can happen with performing forecast analysis without `fiona` installed
* Pins `pip` below v23.1 as the newest changes deprecate `--install-options` 

## More Information

https://github.com/pypa/pip/issues/11358