### PR TITLE
Remove obsolete caches GitHub Workflow

### DIFF
--- a/.github/workflows/remove-obsolete-cache.yml
+++ b/.github/workflows/remove-obsolete-cache.yml
@@ -1,0 +1,35 @@
+# Example taken from https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#managing-caches
+name: Cleanup Caches on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: debug-statements
       - id: pretty-format-json
         args: [ '--autofix', '--no-ensure-ascii', '--no-sort-keys' ]
+        exclude: .ipynb
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 
 * `RavenPy` now uses `platformdirs` to write `raven_testing` to the user's cache directory. Dynamic paths are now used to cache data dependent on the user's operating system. Developers can now safely delete the `.raven_testing_data` folder in their home directory without affecting the functionality of `RavenPy`.
 * Updated `raven-hydro` to v0.2.4 to address CMake build issues.
+* Added a workflow to remove obsolete GitHub Workflow cache files.
 
 0.12.2 (2023-07-04)
 -------------------

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python >=3.8,<3.12
   - raven-hydro ==0.2.4
+  - libgcc  # for mixing raven-hydro from PyPI with conda environments
   - affine
   - cftime
   - cf_xarray


### PR DESCRIPTION
### Changes

* Adds a GitHub Workflow that removes caches from a branch when merged to the main branch