### PR TITLE
Configurable servers

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,8 +4,7 @@
 Contributing
 ============
 
-Contributions are welcome, and they are greatly appreciated! Every little bit
-helps, and credit will always be given.
+Contributions are welcome, and they are greatly appreciated! Every little bit helps, and credit will always be given.
 
 You can contribute in many ways:
 
@@ -26,21 +25,17 @@ If you are reporting a bug, please include:
 Fix Bugs
 ~~~~~~~~
 
-Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
-wanted" is open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with "bug" and "help wanted" is open to whoever wants to implement it.
 
 Implement Features
 ~~~~~~~~~~~~~~~~~~
 
-Look through the GitHub issues for features. Anything tagged with "enhancement"
-and "help wanted" is open to whoever wants to implement it.
+Look through the GitHub issues for features. Anything tagged with "enhancement" and "help wanted" is open to whoever wants to implement it.
 
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-RavenPy could always use more documentation, whether as part of the
-official RavenPy docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+RavenPy could always use more documentation, whether as part of the official RavenPy docs, in docstrings, or even on the web in blog posts, articles, and such.
 
 Submit Feedback
 ~~~~~~~~~~~~~~~
@@ -90,7 +85,7 @@ Ready to contribute? Here's how to set up `ravenpy` for local development.
 
     $ flake8 ravenpy tests
     $ black --check ravenpy tests
-    $ python setup.py test  # or `pytest`
+    $ pytest tests
     $ tox
 
    To get flake8, black, and tox, just pip install them into your virtualenv.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,15 @@ History
 
 0.12.4 (unreleased)
 -------------------
-* In tests, set xclim' missing value option to ``skip``. As of xclim 0.45, missing value checks are applied to ``fit`` indicator, meaning that parameters will be set to None if missing values are found in the fitted time series. Wrap calls to ``fit`` with ``xclim.set_options(check_missing="skip")`` to reproduce the previous behavior of xclim.
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+* In tests, set `xclim`'s missing value option to ``skip``. As of `xclim` v0.45, missing value checks are applied to the ``fit`` indicator, meaning that parameters will be set to `None` if missing values are found in the fitted time series. Wrap calls to ``fit`` with ``xclim.set_options(check_missing="skip")`` to reproduce the previous behavior of xclim.
+* `RavenPy` processes and tests that depend on remote THREDDS/GeoServer now allow for optional server URL and file location targets. These can be set with the following environment variables:
+    * `RAVENPY_THREDDS_URL`: URL to the THREDDS-hosted climate data service. Defaults to `https://pavics.ouranos.ca/twitcher/ows/proxy/thredds`.
+    * `RAVENPY_GEOSERVER_URL`: URL to the GeoServer-hosted vector/raster data. Defaults to `https://pavics.ouranos.ca/geoserver`.
+         * This environment variable was previously called `GEO_URL` and was renamed to narrow its scope to RavenPy.
+* The `_determine_upstream_ids` function under `ravenpy.utilities.geoserver` has been removed as it was a duplicate of `ravenpy.utilities.geo.determine_upstream_ids`. The latter function is now used in its place.
 
 0.12.3 (2023-08-25)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,11 +8,14 @@ History
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * In tests, set `xclim`'s missing value option to ``skip``. As of `xclim` v0.45, missing value checks are applied to the ``fit`` indicator, meaning that parameters will be set to `None` if missing values are found in the fitted time series. Wrap calls to ``fit`` with ``xclim.set_options(check_missing="skip")`` to reproduce the previous behavior of xclim.
-* `RavenPy` processes and tests that depend on remote THREDDS/GeoServer now allow for optional server URL and file location targets. These can be set with the following environment variables:
-    * `RAVENPY_THREDDS_URL`: URL to the THREDDS-hosted climate data service. Defaults to `https://pavics.ouranos.ca/twitcher/ows/proxy/thredds`.
-    * `RAVENPY_GEOSERVER_URL`: URL to the GeoServer-hosted vector/raster data. Defaults to `https://pavics.ouranos.ca/geoserver`.
-         * This environment variable was previously called `GEO_URL` and was renamed to narrow its scope to RavenPy.
+* `RavenPy` processes and tests that depend on remote GeoServer calls now allow for optional server URL and file location targets. The server URL can be set globally with the following environment variable:
+    * `RAVENPY_GEOSERVER_URL`: URL to the GeoServer-hosted vector/raster data. Defaults to `https://pavics.ouranos.ca/geoserver`. This environment variable was previously called `GEO_URL` and was renamed to narrow its scope to `RavenPy`. For the being, `GEO_URL` is still supported for backward compatibility.
 * The `_determine_upstream_ids` function under `ravenpy.utilities.geoserver` has been removed as it was a duplicate of `ravenpy.utilities.geo.determine_upstream_ids`. The latter function is now used in its place.
+
+Internal changes
+^^^^^^^^^^^^^^^^
+* `RavenPy` now accepts a `RAVENPY_THREDDS_URL` for setting the URL globally to the THREDDS-hosted climate data service. Defaults to `https://pavics.ouranos.ca/twitcher/ows/proxy/thredds`.
+* `RavenPy` has temporarily pinned `xarray` below v2023.9.0 due to incompatibilities with `xclim`<=0.45.0.
 
 0.12.3 (2023-08-25)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,13 +8,13 @@ History
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * In tests, set `xclim`'s missing value option to ``skip``. As of `xclim` v0.45, missing value checks are applied to the ``fit`` indicator, meaning that parameters will be set to `None` if missing values are found in the fitted time series. Wrap calls to ``fit`` with ``xclim.set_options(check_missing="skip")`` to reproduce the previous behavior of xclim.
-* `RavenPy` processes and tests that depend on remote GeoServer calls now allow for optional server URL and file location targets. The server URL can be set globally with the following environment variable:
-    * `RAVENPY_GEOSERVER_URL`: URL to the GeoServer-hosted vector/raster data. Defaults to `https://pavics.ouranos.ca/geoserver`. This environment variable was previously called `GEO_URL` and was renamed to narrow its scope to `RavenPy`. For the being, `GEO_URL` is still supported for backward compatibility.
 * The `_determine_upstream_ids` function under `ravenpy.utilities.geoserver` has been removed as it was a duplicate of `ravenpy.utilities.geo.determine_upstream_ids`. The latter function is now used in its place.
 
 Internal changes
 ^^^^^^^^^^^^^^^^
 * `RavenPy` now accepts a `RAVENPY_THREDDS_URL` for setting the URL globally to the THREDDS-hosted climate data service. Defaults to `https://pavics.ouranos.ca/twitcher/ows/proxy/thredds`.
+* `RavenPy` processes and tests that depend on remote GeoServer calls now allow for optional server URL and file location targets. The server URL can be set globally with the following environment variable:
+    * `RAVENPY_GEOSERVER_URL`: URL to the GeoServer-hosted vector/raster data. Defaults to `https://pavics.ouranos.ca/geoserver`. This environment variable was previously called `GEO_URL` and was renamed to narrow its scope to `RavenPy`. For the being, `GEO_URL` is still supported for backward compatibility.
 * `RavenPy` has temporarily pinned `xarray` below v2023.9.0 due to incompatibilities with `xclim` v0.45.0`.
 
 0.12.3 (2023-08-25)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,7 +14,8 @@ Internal changes
 ^^^^^^^^^^^^^^^^
 * `RavenPy` now accepts a `RAVENPY_THREDDS_URL` for setting the URL globally to the THREDDS-hosted climate data service. Defaults to `https://pavics.ouranos.ca/twitcher/ows/proxy/thredds`.
 * `RavenPy` processes and tests that depend on remote GeoServer calls now allow for optional server URL and file location targets. The server URL can be set globally with the following environment variable:
-    * `RAVENPY_GEOSERVER_URL`: URL to the GeoServer-hosted vector/raster data. Defaults to `https://pavics.ouranos.ca/geoserver`. This environment variable was previously called `GEO_URL` and was renamed to narrow its scope to `RavenPy`. For the being, `GEO_URL` is still supported for backward compatibility.
+    * `RAVENPY_GEOSERVER_URL`: URL to the GeoServer-hosted vector/raster data. Defaults to `https://pavics.ouranos.ca/geoserver`. This environment variable was previously called `GEO_URL` but was renamed to narrow its scope to `RavenPy`.
+        * `GEO_URL` is still supported for backward compatibility but may eventually be removed in a future release.
 * `RavenPy` has temporarily pinned `xarray` below v2023.9.0 due to incompatibilities with `xclim` v0.45.0`.
 
 0.12.3 (2023-08-25)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,7 +15,7 @@ Breaking changes
 Internal changes
 ^^^^^^^^^^^^^^^^
 * `RavenPy` now accepts a `RAVENPY_THREDDS_URL` for setting the URL globally to the THREDDS-hosted climate data service. Defaults to `https://pavics.ouranos.ca/twitcher/ows/proxy/thredds`.
-* `RavenPy` has temporarily pinned `xarray` below v2023.9.0 due to incompatibilities with `xclim`<=0.45.0.
+* `RavenPy` has temporarily pinned `xarray` below v2023.9.0 due to incompatibilities with `xclim` v0.45.0`.
 
 0.12.3 (2023-08-25)
 -------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,8 +5,7 @@ Installation
 Anaconda Python Installation
 ----------------------------
 
-For many reasons, we recommend using a `Conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
-to work with the full RavenPy installation. This implementation is able to manage the harder-to-install GIS dependencies, like `GDAL`.
+For many reasons, we recommend using a `Conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_ to work with the full RavenPy installation. This implementation is able to manage the harder-to-install GIS dependencies, like `GDAL`.
 
 Begin by creating an environment:
 
@@ -26,8 +25,7 @@ RavenPy can then be installed directly via its `conda-forge` package by running:
 
    (ravenpy) $ conda install -c conda-forge ravenpy
 
-This approach installs the `Raven <http://raven.uwaterloo.ca>`_ binary directly to your environment `PATH`,
-as well as installs all the necessary Python and C libraries supporting GIS functionalities.
+This approach installs the `Raven <http://raven.uwaterloo.ca>`_ binary directly to your environment `PATH`, as well as installs all the necessary Python and C libraries supporting GIS functionalities.
 
 Python Installation (pip)
 -------------------------
@@ -71,10 +69,22 @@ Once downloaded/compiled, the binary can be pointed to manually (as an absolute 
 
    $ export RAVENPY_RAVEN_BINARY_PATH=/path/to/my/custom/raven
 
+Customizing remote service datasets
+-----------------------------------
+
+A number of functions and tests within `RavenPy` are dependent on remote services (THREDDS, GeoServer) for providing climate datasets, hydrological boundaries, and other data. These services are provided by `Ouranos <https://www.ouranos.ca>`_ through the `PAVICS <https://pavics.ouranos.ca>`_ project and may be subject to change in the future.
+
+If for some reason you wish to use alternate services, you can set the following environment variables to point to your own instances of THREDDS and GeoServer:
+
+.. code-block:: console
+
+   $ export RAVENPY_THREDDS_URL=https://my.domain.org/thredds
+   $ export RAVENPY_GEOSERVER_URL=https://my.domain.org/geoserver
+
 Development Installation (from sources)
 ---------------------------------------
 
-The sources for RavenPy can be obtained from the GitHub repo:
+The sources for `RavenPy` can be obtained from the GitHub repo:
 
 .. code-block:: console
 

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - shapely
   - spotpy
   - statsmodels
-  - xarray
+  - xarray >=2022.12.0,<2023.9.0  # xarray v2023.9.0 is incompatible with xclim<=0.45.0
   - xclim >=0.43
   - xesmf
   - xskillscore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "scipy",
   "spotpy",
   "statsmodels",
-  "xarray",
+  "xarray>=2022.12.0,<2023.9.0", # xarray v2023.9.0 is incompatible with xclim<=0.45.0
   "xclim>=0.43.0",
   "xskillscore"
 ]

--- a/ravenpy/extractors/forecasts.py
+++ b/ravenpy/extractors/forecasts.py
@@ -49,7 +49,7 @@ def get_CASPAR_dataset(
     climate_model: str,
     date: dt.datetime,
     thredds: str = THREDDS_URL,
-    directory: str = "dodsC/birdhouse/disk2/caspar/daily",
+    directory: str = "dodsC/birdhouse/disk2/caspar/daily/",
 ) -> Tuple[
     xr.Dataset, List[Union[Union[DatetimeIndex, Series, Timestamp, Timestamp], Any]]
 ]:
@@ -62,9 +62,9 @@ def get_CASPAR_dataset(
     date : dt.datetime
         The date of the forecast.
     thredds : str
-        The thredds server url. Default: "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds"
+        The thredds server url. Default: "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/"
     directory : str
-        The directory on the thredds server where the data is stored. Default: "dodsC/birdhouse/disk2/caspar/daily"
+        The directory on the thredds server where the data is stored. Default: "dodsC/birdhouse/disk2/caspar/daily/"
 
     Returns
     -------
@@ -96,7 +96,7 @@ def get_CASPAR_dataset(
 def get_ECCC_dataset(
     climate_model: str,
     thredds: str = THREDDS_URL,
-    directory: str = "dodsC/datasets/forecasts/eccc_geps",
+    directory: str = "dodsC/datasets/forecasts/eccc_geps/",
 ) -> Tuple[
     Dataset, List[Union[Union[DatetimeIndex, Series, Timestamp, Timestamp], Any]]
 ]:
@@ -107,9 +107,9 @@ def get_ECCC_dataset(
     climate_model : str
         Type of climate model, for now only "GEPS" is supported.
     thredds : str
-        The thredds server url. Default: "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds"
+        The thredds server url. Default: "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/"
     directory : str
-        The directory on the thredds server where the data is stored. Default: "dodsC/datasets/forecasts/eccc_geps"
+        The directory on the thredds server where the data is stored. Default: "dodsC/datasets/forecasts/eccc_geps/"
 
     Returns
     -------

--- a/ravenpy/extractors/forecasts.py
+++ b/ravenpy/extractors/forecasts.py
@@ -1,6 +1,8 @@
 import datetime as dt
 import logging
+import os
 import re
+from urllib.parse import urljoin
 from pathlib import Path
 from typing import Any, List, Tuple, Union
 
@@ -18,6 +20,9 @@ except (ImportError, ModuleNotFoundError) as e:
     raise ImportError(msg) from e
 
 LOGGER = logging.getLogger("PYWPS")
+THREDDS_URL = os.environ.get(
+    "RAVENPY_THREDDS_URL", "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds"
+)
 
 
 def get_hindcast_day(region_coll: fiona.Collection, date, climate_model="GEPS"):
@@ -38,15 +43,36 @@ def get_hindcast_day(region_coll: fiona.Collection, date, climate_model="GEPS"):
 
 
 def get_CASPAR_dataset(
-    climate_model: str, date: dt.datetime
+    climate_model: str,
+    date: dt.datetime,
+    thredds: str = THREDDS_URL,
+    directory: str = "dodsC/birdhouse/disk2/caspar/daily",
 ) -> Tuple[
     xr.Dataset, List[Union[Union[DatetimeIndex, Series, Timestamp, Timestamp], Any]]
 ]:
-    """Return CASPAR dataset."""
+    """Return CASPAR dataset.
+
+    Parameters
+    ----------
+    climate_model : str
+        Type of climate model, for now only "GEPS" is supported.
+    date : dt.datetime
+        The date of the forecast.
+    thredds : str
+        The thredds server url. Default: "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds"
+    directory : str
+        The directory on the thredds server where the data is stored. Default: "dodsC/birdhouse/disk2/caspar/daily"
+
+    Returns
+    -------
+    xr.Dataset
+        The forecast dataset.
+    """
 
     if climate_model == "GEPS":
         d = dt.datetime.strftime(date, "%Y%m%d")
-        file_url = f"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/disk2/caspar/daily/GEPS_{d}.nc"
+        file_location = urljoin(directory, f"GEPS_{d}.nc")
+        file_url = urljoin(thredds, file_location)
         ds = xr.open_dataset(file_url)
         # Here we also extract the times at 6-hour intervals as Raven must have
         # constant timesteps and GEPS goes to 6 hours
@@ -66,14 +92,31 @@ def get_CASPAR_dataset(
 
 def get_ECCC_dataset(
     climate_model: str,
+    thredds: str = THREDDS_URL,
+    directory: str = "dodsC/datasets/forecasts/eccc_geps",
 ) -> Tuple[
     Dataset, List[Union[Union[DatetimeIndex, Series, Timestamp, Timestamp], Any]]
 ]:
-    """Return latest GEPS forecast dataset."""
+    """Return latest GEPS forecast dataset.
+
+    Parameters
+    ----------
+    climate_model : str
+        Type of climate model, for now only "GEPS" is supported.
+    thredds : str
+        The thredds server url. Default: "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds"
+    directory : str
+        The directory on the thredds server where the data is stored. Default: "dodsC/datasets/forecasts/eccc_geps"
+
+    Returns
+    -------
+    xr.Dataset
+        The forecast dataset.
+    """
     if climate_model == "GEPS":
         # Eventually the file will find a permanent home, until then let's use the test folder.
-        file_url = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/forecasts/eccc_geps/GEPS_latest.ncml"
-
+        file_location = urljoin(directory, "GEPS_latest.ncml")
+        file_url = urljoin(thredds, file_location)
         ds = xr.open_dataset(file_url)
         # Here we also extract the times at 6-hour intervals as Raven must have
         # constant timesteps and GEPS goes to 6 hours
@@ -130,9 +173,10 @@ def get_subsetted_forecast(
     times: Union[dt.datetime, xr.DataArray],
     is_caspar: bool,
 ) -> xr.Dataset:
-    """
+    """Get Subsetted Forecast.
+
     This function takes a dataset, a region and the time sampling array and returns
-    the subsetted values for the given region and times
+    the subsetted values for the given region and times.
 
     Parameters
     ----------
@@ -143,14 +187,12 @@ def get_subsetted_forecast(
     times : dt.datetime or xr.DataArray
         The array of times required to do the forecast.
     is_caspar : bool
-        True if the data comes from Caspar, false otherwise.
-        Used to define lat/lon on rotated grid.
+        True if the data comes from Caspar, false otherwise. Used to define lat/lon on rotated grid.
 
     Returns
     -------
     xr.Dataset
         The forecast dataset.
-
     """
     # Extract the bounding box to subset the entire forecast grid to something
     # more manageable

--- a/ravenpy/extractors/forecasts.py
+++ b/ravenpy/extractors/forecasts.py
@@ -2,9 +2,9 @@ import datetime as dt
 import logging
 import os
 import re
-from urllib.parse import urljoin
 from pathlib import Path
 from typing import Any, List, Tuple, Union
+from urllib.parse import urljoin
 
 import pandas as pd
 import xarray as xr
@@ -20,8 +20,11 @@ except (ImportError, ModuleNotFoundError) as e:
     raise ImportError(msg) from e
 
 LOGGER = logging.getLogger("PYWPS")
+
+# Do not remove the trailing / otherwise `urljoin` will remove the geoserver path.
+# Can be set at runtime with `$ env RAVENPY_THREDDS_URL=https://xx.yy.zz/geoserver/ ...`.
 THREDDS_URL = os.environ.get(
-    "RAVENPY_THREDDS_URL", "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds"
+    "RAVENPY_THREDDS_URL", "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/"
 )
 
 

--- a/ravenpy/extractors/forecasts.py
+++ b/ravenpy/extractors/forecasts.py
@@ -2,6 +2,7 @@ import datetime as dt
 import logging
 import os
 import re
+import warnings
 from pathlib import Path
 from typing import Any, List, Tuple, Union
 from urllib.parse import urljoin
@@ -21,11 +22,12 @@ except (ImportError, ModuleNotFoundError) as e:
 
 LOGGER = logging.getLogger("PYWPS")
 
-# Do not remove the trailing / otherwise `urljoin` will remove the geoserver path.
 # Can be set at runtime with `$ env RAVENPY_THREDDS_URL=https://xx.yy.zz/geoserver/ ...`.
 THREDDS_URL = os.environ.get(
     "RAVENPY_THREDDS_URL", "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/"
 )
+if not THREDDS_URL.endswith("/"):
+    THREDDS_URL = f"{THREDDS_URL}/"
 
 
 def get_hindcast_day(region_coll: fiona.Collection, date, climate_model="GEPS"):
@@ -71,6 +73,11 @@ def get_CASPAR_dataset(
     xr.Dataset
         The forecast dataset.
     """
+    if thredds[-1] != "/":
+        warnings.warn(
+            "The thredds url should end with a slash. Appending it to the url."
+        )
+        thredds = f"{thredds}/"
 
     if climate_model == "GEPS":
         d = dt.datetime.strftime(date, "%Y%m%d")
@@ -116,6 +123,12 @@ def get_ECCC_dataset(
     xr.Dataset
         The forecast dataset.
     """
+    if thredds[-1] != "/":
+        warnings.warn(
+            "The thredds url should end with a slash. Appending it to the url."
+        )
+        thredds = f"{thredds}/"
+
     if climate_model == "GEPS":
         # Eventually the file will find a permanent home, until then let's use the test folder.
         file_location = urljoin(directory, "GEPS_latest.ncml")

--- a/ravenpy/utilities/forecasting.py
+++ b/ravenpy/utilities/forecasting.py
@@ -6,11 +6,11 @@ Created on Fri Jul 17 09:11:58 2020
 """
 import datetime as dt
 import logging
-import tempfile
 import os
+import tempfile
 from pathlib import Path
-from urllib.parse import urlparse
 from typing import List, Union
+from urllib.parse import urlparse
 
 import climpred
 import xarray as xr
@@ -22,8 +22,10 @@ from ravenpy.config.rvs import Config
 
 LOGGER = logging.getLogger("PYWPS")
 
+# Do not remove the trailing / otherwise `urljoin` will remove the geoserver path.
+# Can be set at runtime with `$ env RAVENPY_THREDDS_URL=https://xx.yy.zz/thredds/ ...`.
 THREDDS_URL = os.environ.get(
-    "RAVENPY_THREDDS_URL", "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds"
+    "RAVENPY_THREDDS_URL", "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/"
 )
 
 

--- a/ravenpy/utilities/forecasting.py
+++ b/ravenpy/utilities/forecasting.py
@@ -8,6 +8,7 @@ import datetime as dt
 import logging
 import os
 import tempfile
+import warnings
 from pathlib import Path
 from typing import List, Union
 from urllib.parse import urlparse
@@ -22,11 +23,12 @@ from ravenpy.config.rvs import Config
 
 LOGGER = logging.getLogger("PYWPS")
 
-# Do not remove the trailing / otherwise `urljoin` will remove the geoserver path.
 # Can be set at runtime with `$ env RAVENPY_THREDDS_URL=https://xx.yy.zz/thredds/ ...`.
 THREDDS_URL = os.environ.get(
     "RAVENPY_THREDDS_URL", "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/"
 )
+if not THREDDS_URL.endswith("/"):
+    THREDDS_URL = f"{THREDDS_URL}/"
 
 
 def climatology_esp(
@@ -412,13 +414,18 @@ def compute_forecast_flood_risk(
         Flood level threshold. Will be used to determine if forecasts exceed
         this specified flood threshold. Should be in the same units as the forecasted streamflow.
     thredds : str
-        The thredds server url. Default: "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds"
+        The thredds server url. Default: "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/"
 
     Returns
     -------
     xr.Dataset
         Time series of probabilities of flood level exceedance.
     """
+    if thredds[-1] != "/":
+        warnings.warn(
+            "The thredds url should end with a slash. Appending it to the url."
+        )
+        thredds = f"{thredds}/"
 
     # ---- Calculations ---- #
     # Ensemble: for each day, calculate the percentage of members that are above the threshold

--- a/ravenpy/utilities/geoserver.py
+++ b/ravenpy/utilities/geoserver.py
@@ -49,7 +49,6 @@ except (ImportError, ModuleNotFoundError):
 
 from .geo import determine_upstream_ids
 
-# Do not remove the trailing / otherwise `urljoin` will remove the geoserver path.
 # Can be set at runtime with `$ env RAVENPY_GEOSERVER_URL=https://xx.yy.zz/geoserver/ ...`.
 # For legacy reasons, we also accept the `GEO_URL` environment variable.
 GEOSERVER_URL = os.getenv(

--- a/ravenpy/utilities/geoserver.py
+++ b/ravenpy/utilities/geoserver.py
@@ -6,7 +6,7 @@ Working assumptions for this module:
 * BBox coordinates are passed as (lon1, lat1, lon2, lat2).
 * Shapes (polygons) are passed as shapely.geometry.shape parsable objects.
 * All functions that require a CRS have a CRS argument with a default set to WGS84.
-* GEO_URL points to the GeoServer instance hosting all files.
+* GEOSERVER_URL points to the GeoServer instance hosting all files.
 
 TODO: Refactor to remove functions that are just 2-lines of code.
 For example, many function's logic essentially consists in creating the layer name.

--- a/ravenpy/utilities/geoserver.py
+++ b/ravenpy/utilities/geoserver.py
@@ -1,5 +1,4 @@
-"""
-GeoServer interaction operations.
+"""GeoServer interaction operations.
 
 Working assumptions for this module:
 * Point coordinates are passed as shapely.geometry.Point instances.
@@ -7,7 +6,7 @@ Working assumptions for this module:
 * Shapes (polygons) are passed as shapely.geometry.shape parsable objects.
 * All functions that require a CRS have a CRS argument with a default set to WGS84.
 * GEOSERVER_URL points to the GeoServer instance hosting all files.
-    * For legacy reasons, we also accept the `GEO_URL` environment variable.
+* For legacy reasons, we also accept the `GEO_URL` environment variable.
 
 TODO: Refactor to remove functions that are just 2-lines of code.
 For example, many function's logic essentially consists in creating the layer name.

--- a/ravenpy/utilities/geoserver.py
+++ b/ravenpy/utilities/geoserver.py
@@ -66,6 +66,15 @@ hybas_regions = ["na", "ar"]
 hybas_domains = {dom: hybas_dir / hybas_pat.format(domain=dom) for dom in hybas_regions}
 
 
+def _fix_server_url(server_url: str) -> str:
+    if not server_url.endswith("/"):
+        warnings.warn(
+            "The GeoServer url should end with a slash. Appending it to the url."
+        )
+        return f"{server_url}/"
+    return server_url
+
+
 def _get_location_wfs(
     bbox: Optional[
         Tuple[
@@ -105,11 +114,7 @@ def _get_location_wfs(
     dict
         A GeoJSON-derived dictionary of vector features (FeatureCollection).
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     wfs = WebFeatureService(url=urljoin(geoserver, "wfs"), version="2.0.0", timeout=30)
 
@@ -170,11 +175,7 @@ def _get_feature_attributes_wfs(
     -----
     Non-existent attributes will raise a cryptic DriverError from fiona.
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     params = dict(
         service="WFS",
@@ -212,11 +213,7 @@ def _filter_feature_attributes_wfs(
     str
       WFS request URL.
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     try:
         attribute = str(attribute)
@@ -266,11 +263,7 @@ def get_raster_wcs(
     bytes
         A GeoTIFF array.
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     (left, down, right, up) = coordinates
 
@@ -441,11 +434,7 @@ def filter_hydrobasins_attributes_wfs(
     str
         URL to the GeoJSON-encoded WFS response.
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     lakes = True
     level = 12
@@ -485,11 +474,7 @@ def get_hydrobasins_location_wfs(
     dict
         A GeoJSON-encoded vector feature.
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     lakes = True
     level = 12
@@ -529,11 +514,7 @@ def hydro_routing_upstream(
     pd.Series
         Basins ids including `fid` and its upstream contributors.
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     wfs = WebFeatureService(url=urljoin(geoserver, "wfs"), version="2.0.0", timeout=30)
     layer = f"public:routing_{lakes}Lakes_{str(level).zfill(2)}"
@@ -591,11 +572,7 @@ def get_hydro_routing_attributes_wfs(
     str
         URL to the GeoJSON-encoded WFS response.
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     layer = f"public:routing_{lakes}Lakes_{str(level).zfill(2)}"
     return _get_feature_attributes_wfs(
@@ -633,11 +610,7 @@ def filter_hydro_routing_attributes_wfs(
     str
         URL to the GeoJSON-encoded WFS response.
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     layer = f"public:routing_{lakes}Lakes_{str(level).zfill(2)}"
     return _filter_feature_attributes_wfs(
@@ -675,11 +648,7 @@ def get_hydro_routing_location_wfs(
     dict
         A GeoJSON-derived dictionary of vector features (FeatureCollection).
     """
-    if not geoserver.endswith("/"):
-        warnings.warn(
-            "The GeoServer url should end with a slash. Appending it to the url."
-        )
-        geoserver = f"{geoserver}/"
+    geoserver = _fix_server_url(geoserver)
 
     layer = f"public:routing_{lakes}Lakes_{str(level).zfill(2)}"
 

--- a/ravenpy/utilities/geoserver.py
+++ b/ravenpy/utilities/geoserver.py
@@ -48,14 +48,13 @@ except (ImportError, ModuleNotFoundError):
 
 from .geo import determine_upstream_ids
 
-
 # Do not remove the trailing / otherwise `urljoin` will remove the geoserver path.
-# Can be set at runtime with `$ env GEO_URL=https://xx.yy.zz/geoserver/ ...`.
+# Can be set at runtime with `$ env RAVENPY_GEOSERVER_URL=https://xx.yy.zz/geoserver/ ...`.
 GEOSERVER_URL = os.getenv(
     "RAVENPY_GEOSERVER_URL", "https://pavics.ouranos.ca/geoserver/"
 )
 
-# We store the contour of different hydrobasins domains
+# We store the contour of different HydroBASINS domains
 hybas_dir = Path(__file__).parent.parent / "data" / "hydrobasins_domains"
 hybas_pat = "hybas_lake_{domain}_lev01_v1c.zip"
 

--- a/ravenpy/utilities/testdata.py
+++ b/ravenpy/utilities/testdata.py
@@ -1,7 +1,6 @@
 """Tools for searching for and acquiring test data."""
 import hashlib
 import logging
-import os
 import re
 import warnings
 from pathlib import Path


### PR DESCRIPTION
FYI @fmigneault

### Changes
* The THREDDS and GeoServer instances can now be configured for staging/testing purposes. These new environment variables are documented within the installation docs:
    * `RAVENPY_THREDDS_URL`: URL to the THREDDS-hosted climate data service. Defaults to `https://pavics.ouranos.ca/twitcher/ows/proxy/thredds`.
    * `RAVENPY_GEOSERVER_URL`: URL to the GeoServer-hosted vector/raster data. Defaults to `https://pavics.ouranos.ca/geoserver`.
        * This environment variable `GEO_URL` is still valid for legacy purposes.
* The `_determine_upstream_ids` function under `ravenpy.utilities.geoserver` was a direct copy of `determine_upstream_ids` found in `ravenpy.utilities.geo` and has been removed.
* The `get_CASPAR_dataset` and `get_ECCC_dataset` functions now accept a `thredds` and a `directory` in their call signatures for specifying file location.
* Pins `xarray` below `2023.09.0` until xclim addresses compatibility issues (will be fixed in `0.46.0`).

### Relevant discussion:

https://github.com/bird-house/birdhouse-deploy/issues/14?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDY5OTA0MTYxODoxMDgxOTUyNA%3D%3D#issuecomment-1730183776