### PR TITLE
Fix notebook execution

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,8 +17,6 @@ build:
   tools:
     python: "mambaforge-4.10"
   jobs:
-    post_install:
-      - pip install .[docs]
     pre_build:
       - env SPHINX_APIDOC_OPTIONS="members,undoc-members,show-inheritance,noindex" sphinx-apidoc -o docs/apidoc --private --module-first ravenpy
       - sphinx-build -b linkcheck docs/ _build/linkcheck || true
@@ -29,9 +27,10 @@ formats:
 conda:
   environment: environment-rtd.yml
 
-#python:
-#  install:
-#    - method: pip
-#      path: .
-#      extra_requirements:
-#        - dev
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev
+        - docs


### PR DESCRIPTION
### Changes

 * Installs RavenPy using the ReadTheDocs `Python` block

### Discussion

Currently, the Jupyter (non-MyST) notebooks are not run (nbsphinx is not in the extensions. Is the plan to prgressively move these over to the MyST standard ?