### PR TITLE
Refactor and simplify testing data fetching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,10 +80,6 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         echo "GDAL_VERSION=$(gdalinfo --version | awk  '{print $2}' | sed s'/.$//')" >> $GITHUB_ENV
-    - name: Hotfix GDAL_VERSION (3.7.1 -> 3.7.1.1)
-      if: env.GDAL_VERSION == '3.7.1'
-      run: |
-        echo "GDAL_VERSION=$GDAL_VERSION.1" >> $GITHUB_ENV
 
     - name: Install tox
       run: |
@@ -127,6 +123,7 @@ jobs:
         with:
           cache-downloads: true
           cache-environment: true
+          cache-environment-key: environment-${{ matrix.python-version }}-${{ matrix.os }}-${{ github.head_ref }}
           environment-file: environment.yml
           create-args: >-
             conda

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/.jupyter_cache
+docs/apidoc/modules.rst
+docs/apidoc/ravenpy*.rst
 docs/jupyter_execute
 
 # PyBuilder

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,9 +4,19 @@ History
 
 0.13 (unreleased)
 -----------------
-* Update to Pydantic v2
 * Fixed problem with scalar elevation in netCDF files parsed with `nc_specs` (issue #279)
-* Add notebook on sensitivity analysis.
+* Added notebook on sensitivity analysis.
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+* Update to Pydantic v2.
+* Added `h5netcdf` as a core dependency to provide a stabler backend for `xarray.open_dataset`.
+* Switched from `autodoc_pydantic` to `autodoc-pydantic` for `pydantic` v2.0+ support in documentation.
+
+Internal changes
+^^^^^^^^^^^^^^^^
+* Removed some redundant `pytest` fixtures for running `emulators` tests.
+* `"session"`-scoped `pytest` fixtures used for hindcasting/forecasting are now always yielded and copied to new objects within tests.
 
 0.12.3 (2023-10-02)
 -------------------

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - flit
   - gdal >=3.1
   - geopandas >=0.13.0
+  - h5netcdf
   - haversine
   - holoviews
   - hvplot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dev = [
   "watchdog"
 ]
 docs = [
-  "autodoc_pydantic",
+  "autodoc-pydantic",
   "birdhouse-birdy",
   "cartopy",
   "clisops",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "climpred>=2.4.0",
   "dask",
   "haversine",
+  "h5netcdf",
   "matplotlib",
   "netCDF4",
   "numpy<1.25",

--- a/ravenpy/config/commands.py
+++ b/ravenpy/config/commands.py
@@ -680,7 +680,7 @@ class Gauge(FlatCommand):
     @classmethod
     def from_nc(
         cls,
-        fn: Union[Path, Sequence[Path]],
+        fn: Union[str, Path, Sequence[Path]],
         data_type: Sequence[str] = None,
         station_idx: int = 1,
         alt_names: Optional[Dict[str, str]] = None,
@@ -692,7 +692,7 @@ class Gauge(FlatCommand):
 
         Parameters
         ----------
-        fn : Union[Path, Sequence[Path]],
+        fn : Union[str, Path, Sequence[Path]],
             NetCDF file path or paths.
         data_type : Sequence[str], None
             Raven data types to extract from netCDF files, e.g. 'PRECIP', 'AVE_TEMP'. The algorithm tries to find all

--- a/ravenpy/config/commands.py
+++ b/ravenpy/config/commands.py
@@ -533,7 +533,11 @@ class ReadFromNetCDF(FlatCommand):
     def da(self) -> xr.DataArray:
         """Return DataArray from configuration."""
         # TODO: Apply linear transform and time shift
-        da = xr.open_dataset(self.file_name_nc)[self.var_name_nc]
+        # FIXME: Workaround for macOS bug
+        try:
+            da = xr.open_dataset(self.file_name_nc)[self.var_name_nc]
+        except ValueError:
+            da = xr.open_dataset(self.file_name_nc, engine="netcdf4")[self.var_name_nc]
         if len(self.dim_names_nc) == 1:
             return da
         elif len(self.dim_names_nc) == 2:

--- a/ravenpy/config/commands.py
+++ b/ravenpy/config/commands.py
@@ -537,7 +537,7 @@ class ReadFromNetCDF(FlatCommand):
         try:
             da = xr.open_dataset(self.file_name_nc)[self.var_name_nc]
         except ValueError:
-            da = xr.open_dataset(self.file_name_nc, engine="netcdf4")[self.var_name_nc]
+            da = xr.open_dataset(self.file_name_nc, engine="h5netcdf")[self.var_name_nc]
         if len(self.dim_names_nc) == 1:
             return da
         elif len(self.dim_names_nc) == 2:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,22 +9,20 @@ import xarray as xr
 from filelock import FileLock
 from xclim.indicators.generic import fit, stats
 
-from ravenpy.config import commands as rc
-from ravenpy.config.emulators import (
-    GR4JCN,
-    HBVEC,
-    HMETS,
-    HYPR,
-    SACSMA,
-    Blended,
-    CanadianShield,
-    Mohyse,
-)
 from ravenpy.utilities.testdata import _default_cache_dir
 from ravenpy.utilities.testdata import get_file as _get_file
 from ravenpy.utilities.testdata import get_local_testdata as _get_local_testdata
 
 from .common import _convert_2d, _convert_3d
+
+# Additional pytest fixtures for emulators
+from .emulators import (  # noqa: F401
+    config_rv,
+    gr4jcn_config,
+    minimal_emulator,
+    numeric_config,
+    symbolic_config,
+)
 
 RAVEN_TESTING_DATA_BRANCH = os.getenv("RAVEN_TESTING_DATA_BRANCH", "master")
 SKIP_TEST_DATA = os.getenv("RAVENPY_SKIP_TEST_DATA")
@@ -171,470 +169,99 @@ def gather_session_data(threadsafe_data_dir, worker_id):
         shutil.copytree(DEFAULT_CACHE, threadsafe_data_dir)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def cleanup(request):
-    """Cleanup a testing file once we are finished.
-
-    This flag prevents remote data from being downloaded multiple times in the same pytest run.
-    """
-
-    def remove_data_written_flag():
-        flag = DEFAULT_CACHE.joinpath(".data_written")
-        if flag.exists():
-            flag.unlink()
-
-    request.addfinalizer(remove_data_written_flag)
-
-
 @pytest.fixture(scope="session")
-def q_sim_1(threadsafe_data_dir):
+def q_sim_1(threadsafe_data_dir, get_local_testdata):
     """A file storing a Raven streamflow simulation over one basin."""
-    return _get_file(
+    return get_local_testdata(
         "hydro_simulations/raven-gr4j-cemaneige-sim_hmets-0_Hydrographs.nc",
-        cache_dir=threadsafe_data_dir,
-        branch=RAVEN_TESTING_DATA_BRANCH,
     )
 
 
 @pytest.fixture(scope="session")
 def ts_stats(q_sim_1, tmp_path):
-    q = xr.open_dataset(q_sim_1).q_sim
-    ts = stats(q, op="max")
-    fn = tmp_path / "ts_stats.nc"
-    ts.to_netcdf_(fn)
+    with xr.open_dataset(q_sim_1) as ds:
+        q = ds.q_sim
+        ts = stats(q, op="max")
+        fn = tmp_path / "ts_stats.nc"
+        ts.to_netcdf_(fn)
     return fn
 
 
 @pytest.fixture(scope="session")
-def fit_params(ts_stats, tmp_path):
-    fn = tmp_path / "fit.nc"
+def fit_params(ts_stats, threadsafe_data_dir):
+    fn = threadsafe_data_dir / "fit.nc"
 
     if not fn.exists():
-        ds = xr.open_dataset(ts_stats)
-        name = list(ds.data_vars.keys()).pop()
-        q = ds[name]
-        p = fit(q, dist="gumbel_r")
-        p.to_netcdf(fn)
+        with xr.open_dataset(ts_stats) as ds:
+            name = list(ds.data_vars.keys()).pop()
+            q = ds[name]
+            p = fit(q, dist="gumbel_r")
+            p.to_netcdf(fn)
 
-    return fn
+    yield fn
 
 
 @pytest.fixture(scope="session")
-def bad_netcdf(salmon_meteo):
-    fn = salmon_meteo.parent / "bad_netcdf.nc"
+def bad_netcdf(get_local_testdata, threadsafe_data_dir):
+    fn = threadsafe_data_dir / "bad_netcdf.nc"
+
+    salmon_file = get_local_testdata(
+        "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
+    )
 
     if not fn.exists():
         # Test with scalar elevation. Should normally have a station dimension, but not always the case.
-        ds = xr.open_dataset(salmon_meteo)
-        ds["station_name"] = ds["station_name"].astype("str")
-        ds["elevation"] = 1.0
-        ds.to_netcdf(fn)
+        with xr.open_dataset(salmon_file) as ds:
+            ds["station_name"] = ds["station_name"].astype("str")
+            ds["elevation"] = 1.0
+            ds.to_netcdf(fn)
 
     return fn
 
 
 @pytest.fixture(scope="session")
 def salmon_hru():
-    out = {}
-    out["land"] = dict(
-        area=4250.6,
-        elevation=843.0,
-        latitude=54.4848,
-        longitude=-123.3659,
-        hru_type="land",
-    )
-    return out
-
-
-@pytest.fixture(scope="session")
-def salmon_meteo(get_local_testdata):
-    return get_local_testdata(
-        "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
-    )
-
-
-@pytest.fixture(scope="session")
-def salmon(threadsafe_data_dir):
-    """A file storing a Raven streamflow simulation over one basin."""
-    return _get_file(
-        "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc",
-        cache_dir=threadsafe_data_dir,
-        branch=RAVEN_TESTING_DATA_BRANCH,
-    )
+    out = {
+        "land": dict(
+            area=4250.6,
+            elevation=843.0,
+            latitude=54.4848,
+            longitude=-123.3659,
+            hru_type="land",
+        )
+    }
+    yield out
 
 
 # Used in test_emulators.py
 @pytest.fixture(scope="session")
-def input2d(threadsafe_data_dir, salmon):
+def input2d(salmon, threadsafe_data_dir):
     """Convert 1D input to 2D output by copying all the time series along a new region dimension."""
-
     fn_out = threadsafe_data_dir / "input2d.nc"
+
     if not fn_out.exists():
         _convert_2d(salmon).to_netcdf(fn_out)
 
     return fn_out
 
 
-# Used in test_emulators.py
 @pytest.fixture(scope="session")
-def input3d(threadsafe_data_dir, salmon):
+def input3d(salmon, threadsafe_data_dir):
     """Convert 1D input to 2D output by copying all the time series along a new region dimension."""
-
     fn_out = threadsafe_data_dir / "input3d.nc"
+
     if not fn_out.exists():
         ds = _convert_3d(salmon)
         ds = ds.drop_vars("qobs")
         ds.to_netcdf(fn_out)
+        ds.close()
 
     return fn_out
 
 
-# Alternative names for variables in meteo forcing file
-alt_names = {
-    "RAINFALL": "rain",
-    "TEMP_MIN": "tmin",
-    "TEMP_MAX": "tmax",
-    "PET": "pet",
-    "HYDROGRAPH": "qobs",
-    "SNOWFALL": "snow",
-}
-
-# Names of emulators to be included in tests
-names = [
-    "GR4JCN",
-    "HMETS",
-    "Mohyse",
-    "HBVEC",
-    "CanadianShield",
-    "HYPR",
-    "SACSMA",
-    "Blended",
-]
-
-# Mapping of emulator names to configuration classes
-configs = {
-    "GR4JCN": GR4JCN,
-    "HMETS": HMETS,
-    "Mohyse": Mohyse,
-    "HBVEC": HBVEC,
-    "CanadianShield": CanadianShield,
-    "HYPR": HYPR,
-    "SACSMA": SACSMA,
-    "Blended": Blended,
-}
-
-# Model parameters that match NSE criteria computed by Juliane
-params = {
-    "GR4JCN": [0.529, -3.396, 407.29, 1.072, 16.9, 0.947],
-    "HMETS": [
-        9.5019,
-        0.2774,
-        6.3942,
-        0.6884,
-        1.2875,
-        5.4134,
-        2.3641,
-        0.0973,
-        0.0464,
-        0.1998,
-        0.0222,
-        -1.0919,
-        2.6851,
-        0.3740,
-        1.0000,
-        0.4739,
-        0.0114,
-        0.0243,
-        0.0069,
-        310.7211,
-        916.1947,
-    ],
-    "Mohyse": (
-        1.0,
-        0.0468,
-        4.2952,
-        2.658,
-        0.4038,
-        0.0621,
-        0.0273,
-        0.0453,
-        0.9039,
-        5.6167,
-    ),
-    "HBVEC": (
-        0.05984519,
-        4.072232,
-        2.001574,
-        0.03473693,
-        0.09985144,
-        0.506052,
-        3.438486,
-        38.32455,
-        0.4606565,
-        0.06303738,
-        2.277781,
-        4.873686,
-        0.5718813,
-        0.04505643,
-        0.877607,
-        18.94145,
-        2.036937,
-        0.4452843,
-        0.6771759,
-        1.141608,
-        1.024278,
-    ),
-    "CanadianShield": (
-        4.72304300e-01,
-        8.16392200e-01,
-        9.86197600e-02,
-        3.92699900e-03,
-        4.69073600e-02,
-        4.95528400e-01,
-        6.803492000e00,
-        4.33050200e-03,
-        1.01425900e-05,
-        1.823470000e00,
-        5.12215400e-01,
-        9.017555000e00,
-        3.077103000e01,
-        5.094095000e01,
-        1.69422700e-01,
-        8.23412200e-02,
-        2.34595300e-01,
-        7.30904000e-02,
-        1.284052000e00,
-        3.653415000e00,
-        2.306515000e01,
-        2.402183000e00,
-        2.522095000e00,
-        5.80344900e-01,
-        1.614157000e00,
-        6.031781000e00,
-        3.11129800e-01,
-        6.71695100e-02,
-        5.83759500e-05,
-        9.824723000e00,
-        9.00747600e-01,
-        8.04057300e-01,
-        1.179003000e00,
-        7.98001300e-01,
-    ),
-    "HYPR": (
-        -1.856410e-01,
-        2.92301100e00,
-        3.1194200e-02,
-        4.3982810e-01,
-        4.6509760e-01,
-        1.1770040e-01,
-        1.31236800e01,
-        4.0417950e-01,
-        1.21225800e00,
-        5.91273900e01,
-        1.6612030e-01,
-        4.10501500e00,
-        8.2296110e-01,
-        4.15635200e01,
-        5.85111700e00,
-        6.9090140e-01,
-        9.2459950e-01,
-        1.64358800e00,
-        1.59920500e00,
-        2.51938100e00,
-        1.14820100e00,
-    ),
-    "SACSMA": (
-        0.0100000,
-        0.0500000,
-        0.3000000,
-        0.0500000,
-        0.0500000,
-        0.1300000,
-        0.0250000,
-        0.0600000,
-        0.0600000,
-        1.0000000,
-        40.000000,
-        0.0000000,
-        0.0000000,
-        0.1000000,
-        0.0000000,
-        0.0100000,
-        1.5000000,
-        0.4827523,
-        4.0998200,
-        1.0000000,
-        1.0000000,
-    ),
-    "Blended": (
-        2.930702e-02,
-        2.211166e00,
-        2.166229e00,
-        0.0002254976,
-        2.173976e01,
-        1.565091e00,
-        6.211146e00,
-        9.313578e-01,
-        3.486263e-02,
-        0.251835,
-        0.0002279250,
-        1.214339e00,
-        4.736668e-02,
-        0.2070342,
-        7.806324e-02,
-        -1.336429e00,
-        2.189741e-01,
-        3.845617e00,
-        2.950022e-01,
-        4.827523e-01,
-        4.099820e00,
-        1.283144e01,
-        5.937894e-01,
-        1.651588e00,
-        1.705806,
-        3.719308e-01,
-        7.121015e-02,
-        1.906440e-02,
-        4.080660e-01,
-        9.415693e-01,
-        -1.856108e00,
-        2.356995e00,
-        1.0e00,
-        1.0e00,
-        7.510967e-03,
-        5.321608e-01,
-        2.891977e-02,
-        9.605330e-01,
-        6.128669e-01,
-        9.558293e-01,
-        1.008196e-01,
-        9.275730e-02,
-        7.469583e-01,
-    ),
-}
-
-
-@pytest.fixture(scope="session")
-def gr4jcn_config(salmon_meteo, salmon_hru) -> (GR4JCN, params):
-    """Return symbolic config and params for basic gr4jcn."""
-
-    yield GR4JCN(
-        Gauge=[
-            rc.Gauge.from_nc(
-                salmon_meteo,
-                data_type=["RAINFALL", "TEMP_MIN", "TEMP_MAX", "SNOWFALL"],
-                alt_names=alt_names,
-                data_kwds={"ALL": {"elevation": salmon_hru["land"]["elevation"]}},
-            ),
-        ],
-        ObservationData=[rc.ObservationData.from_nc(salmon_meteo, alt_names="qobs")],
-        HRUs=[salmon_hru["land"]],
-        StartDate=dt.datetime(2000, 1, 1),
-        Duration=15,
-        EvaluationMetrics=("NASH_SUTCLIFFE",),
-    ), params["GR4JCN"]
-
-
-@pytest.fixture(scope="session", params=names)
-def symbolic_config(salmon_meteo, salmon_hru, request):
-    """Emulator configuration instantiated with symbolic parameters."""
-    name = request.param
-    cls = configs[name]
-    data_type = ["RAINFALL", "TEMP_MIN", "TEMP_MAX", "SNOWFALL"]
-
-    # Extra attributes for gauges
-    gextras = {"ALL": {"elevation": salmon_hru["land"]["elevation"]}}
-
-    if name in ["HBVEC", "HYPR"]:
-        with xr.open_dataset(salmon_meteo) as ds:
-            gextras["ALL"]["monthly_ave_temperature"] = (
-                ((ds.tmin + ds.tmax) / 2).groupby("time.month").mean().values.tolist()
-            )
-            gextras["ALL"]["monthly_ave_evaporation"] = (
-                ds.pet.groupby("time.month").mean().values.tolist()
-            )
-
-    # Extra attributes for emulator
-    extras = {}
-
-    if name in ["CanadianShield", "HYPR", "SACSMA", "Blended"]:
-        salmon_hru["slope"] = 0.01234
-
-    hrus = [salmon_hru["land"]]
-
-    if name in ["GR4JCN"]:
-        extras.update(
-            dict(
-                GlobalParameter={"AVG_ANNUAL_RUNOFF": 208.480},
-            )
-        )
-    if name in ["HMETS"]:
-        data_type.extend(["PET"])
-
-    if name in ["CanadianShield"]:
-        hrus = [salmon_hru["land"], salmon_hru["land"]]
-        extras["SuppressOutput"] = True
-
-    yield name, cls(
-        Gauge=[
-            rc.Gauge.from_nc(
-                salmon_meteo,
-                data_type=data_type,
-                alt_names=alt_names,
-                data_kwds=gextras,
-            ),
-        ],
-        ObservationData=[rc.ObservationData.from_nc(salmon_meteo, alt_names="qobs")],
-        HRUs=hrus,
-        StartDate=dt.datetime(2000, 1, 1),
-        EndDate=dt.datetime(2002, 1, 1),
-        RunName="test",
-        EvaluationMetrics=("NASH_SUTCLIFFE",),
-        **extras,
-    )
-
-
-@pytest.fixture(scope="session")
-def numeric_config(symbolic_config):
-    """Emulator configuration instantiated with numeric parameters."""
-    name, conf = symbolic_config
-    yield name, conf.set_params(params[name])
-
-
-@pytest.fixture(scope="session")
-def minimal_emulator(salmon_meteo, salmon_hru):
-    """Return the config for a single emulator."""
-    cls = configs["HMETS"]
-    data_type = ["RAINFALL", "TEMP_MIN", "TEMP_MAX", "SNOWFALL", "PET"]
-
-    return cls(
-        params=params["HMETS"],
-        Gauge=[
-            rc.Gauge.from_nc(
-                salmon_meteo,
-                data_type=data_type,
-                alt_names=alt_names,
-            ),
-        ],
-        ObservationData=[rc.ObservationData.from_nc(salmon_meteo, alt_names="qobs")],
-        HRUs=[salmon_hru["land"]],
-        StartDate=dt.datetime(2000, 1, 1),
-        Duration=15,
-    )
-
-
-@pytest.fixture(scope="session")
-def config_rv(tmp_path_factory, numeric_config):
-    """Directory with emulator configuration files written to disk."""
-    name, conf = numeric_config
-    out = tmp_path_factory.mktemp(name) / "config"
-    conf.write_rv(out)
-    yield name, out
-
-
 @pytest.fixture
 def dummy_config():
-    """Return a almost empty config class and the parameter dataclass."""
+    """Return an almost empty config class and the parameter dataclass."""
     from pydantic import Field
     from pydantic.dataclasses import dataclass
 
@@ -654,6 +281,20 @@ def dummy_config():
     return TestConfig, P
 
 
-#
+@pytest.fixture(scope="session", autouse=True)
+def cleanup(request):
+    """Cleanup a testing file once we are finished.
+
+    This flag prevents remote data from being downloaded multiple times in the same pytest run.
+    """
+
+    def remove_data_written_flag():
+        flag = DEFAULT_CACHE.joinpath(".data_written")
+        if flag.exists():
+            flag.unlink()
+
+    request.addfinalizer(remove_data_written_flag)
+
+
 if __name__ == "__main__":
     populate_testing_data(branch=RAVEN_TESTING_DATA_BRANCH)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -347,16 +347,13 @@ def test_gridded_forcing(get_local_testdata):
     # assert gf.dim_names_nc == ("lon_dim", "lat_dim", "time")
 
 
-def test_gauge(get_local_testdata, tmp_path):
-    f = get_local_testdata(
+def test_gauge(get_local_testdata):
+    salmon_file = get_local_testdata(
         "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
-    )
-    f_tmp = copyfile(
-        f, tmp_path.joinpath("Salmon-River-Near-Prince-George_meteo_daily.nc")
     )
 
     g = rc.Gauge.from_nc(
-        f_tmp,
+        salmon_file,
         alt_names={"RAINFALL": "rain", "SNOWFALL": "snow"},
         data_kwds={"ALL": {"Deaccumulate": True}},
     )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -347,13 +347,15 @@ def test_gridded_forcing(get_local_testdata):
     # assert gf.dim_names_nc == ("lon_dim", "lat_dim", "time")
 
 
-def test_gauge(get_local_testdata):
+def test_gauge(get_local_testdata, tmp_path):
     salmon_file = get_local_testdata(
         "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
     )
 
+    copyfile(salmon_file, tmp_path / "Salmon-River-Near-Prince-George_meteo_daily.nc")
+
     g = rc.Gauge.from_nc(
-        salmon_file,
+        tmp_path / "Salmon-River-Near-Prince-George_meteo_daily.nc",
         alt_names={"RAINFALL": "rain", "SNOWFALL": "snow"},
         data_kwds={"ALL": {"Deaccumulate": True}},
     )

--- a/tests/test_distributed_workflow.py
+++ b/tests/test_distributed_workflow.py
@@ -16,7 +16,7 @@ Distributed model workflow
 """
 
 
-def test_simple_workflow(get_local_testdata, minimal_emulator, tmp_path):
+def test_simple_workflow(get_local_testdata, tmp_path):
     shp_path = get_local_testdata(
         "basinmaker/drainage_region_0175_v2-1/finalcat_info_v2-1.zip"
     )

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -180,7 +180,7 @@ def test_run_with_dap_link(minimal_emulator, tmp_path):
     }
 
     # Modifying of a session-scoped pytest fixture will cause problems with other tests.
-    conf = minimal_emulator.copy()
+    conf = minimal_emulator.model_copy(deep=True)
     conf.gauge = [rc.Gauge.from_nc(dap_link, alt_names=alt_names)]
 
     Emulator(conf, workdir=tmp_path).run()

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -165,8 +165,10 @@ def test_evaluation_periods(gr4jcn_config, tmp_path):
 def test_run_with_dap_link(minimal_emulator, tmp_path):
     """Test Raven with DAP link instead of local netCDF file."""
     # Link to THREDDS Data Server netCDF testdata
-    TDS = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/raven"
-    fn = f"{TDS}/raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
+    thredds = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/raven"
+    dap_link = (
+        f"{thredds}/raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
+    )
 
     alt_names = {
         "RAINFALL": "rain",
@@ -177,8 +179,9 @@ def test_run_with_dap_link(minimal_emulator, tmp_path):
         "SNOWFALL": "snow",
     }
 
-    conf = minimal_emulator
-    conf.gauge = [rc.Gauge.from_nc(fn, alt_names=alt_names)]
+    # Modifying of a session-scoped pytest fixture will cause problems with other tests.
+    conf = minimal_emulator.copy()
+    conf.gauge = [rc.Gauge.from_nc(dap_link, alt_names=alt_names)]
 
     Emulator(conf, workdir=tmp_path).run()
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -15,23 +15,27 @@ alt_names = {
 
 
 # @pytest.mark.xfail()
-def test_enkf(salmon_meteo, salmon_hru, tmp_path):
+def test_enkf(get_local_testdata, salmon_hru, tmp_path):
     """Test one run of Ensemble Kalman Filter data assimilation."""
     cls = GR4JCN
     # name = "GR4JCN"
     data_type = ["RAINFALL", "TEMP_MIN", "TEMP_MAX", "SNOWFALL"]
 
+    salmon_file = get_local_testdata(
+        "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
+    )
+
     conf = cls(
         params=(0.14, -0.005, 576, 7.0, 1.1, 0.92),
         Gauge=[
             rc.Gauge.from_nc(
-                salmon_meteo,
+                salmon_file,
                 data_type=data_type,
                 alt_names=alt_names,
                 data_kwds={"ALL": {"elevation": salmon_hru["land"]["elevation"]}},
             ),
         ],
-        ObservationData=[rc.ObservationData.from_nc(salmon_meteo, alt_names="qobs")],
+        ObservationData=[rc.ObservationData.from_nc(salmon_file, alt_names="qobs")],
         HRUs=[salmon_hru["land"]],
         StartDate=dt.datetime(1996, 9, 1),
         EndDate=dt.datetime(1996, 9, 30),

--- a/tests/test_forecasting.py
+++ b/tests/test_forecasting.py
@@ -24,28 +24,30 @@ def test_warm_up(minimal_emulator, tmp_path):
 
 
 def test_climatology_esp(minimal_emulator, tmp_path):
-    esp = climatology_esp(minimal_emulator, workdir=tmp_path, years=[1955, 1956])
+    config = minimal_emulator.copy()
+    esp = climatology_esp(config, workdir=tmp_path, years=[1955, 1956])
     np.testing.assert_array_equal(esp.storage.member, [1955, 1956])
     assert len(esp.hydrograph.time) == minimal_emulator.duration + 1
 
 
-def test_hindcast_climatology_esp(minimal_emulator, tmp_path, get_file):
+def test_hindcast_climatology_esp(minimal_emulator, tmp_path, get_local_testdata):
+    config = minimal_emulator.copy()
     hc = hindcast_climatology_esp(
-        minimal_emulator,
+        config,
         warm_up_duration=5,
         years=[1955, 1956, 1957],
         hindcast_years=[1990, 1991],
         workdir=tmp_path,
     )
     assert hc.sizes == {
-        "lead": minimal_emulator.duration + 1,
+        "lead": config.duration + 1,
         "init": 2,
         "member": 3,
         "nbasins": 1,
     }
 
     # Construct climpred HindcastEnsemble
-    salmon_file = get_file(
+    salmon_file = get_local_testdata(
         "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
     )
     qobs = xr.open_dataset(salmon_file).qobs
@@ -59,13 +61,11 @@ def test_hindcast_climatology_esp(minimal_emulator, tmp_path, get_file):
         dim=["member", "init"],
         alignment="same_inits",
     )
-    assert rank_histo_verif.q_sim.shape[0] == minimal_emulator.duration + 1
+    assert rank_histo_verif.q_sim.shape[0] == config.duration + 1
 
 
 def test_forecasting_GEPS(numeric_config, get_local_testdata):
-    """
-    Test to perform a forecast using auto-queried ECCC data aggregated on THREDDS.
-    """
+    """Test to perform a forecast using auto-queried ECCC data aggregated on THREDDS."""
     name, wup = numeric_config
     if name != "GR4JCN":
         pytest.skip()

--- a/tests/test_forecasting.py
+++ b/tests/test_forecasting.py
@@ -29,7 +29,7 @@ def test_climatology_esp(minimal_emulator, tmp_path):
     assert len(esp.hydrograph.time) == minimal_emulator.duration + 1
 
 
-def test_hindcast_climatology_esp(minimal_emulator, tmp_path, salmon_meteo):
+def test_hindcast_climatology_esp(minimal_emulator, tmp_path, get_file):
     hc = hindcast_climatology_esp(
         minimal_emulator,
         warm_up_duration=5,
@@ -45,7 +45,11 @@ def test_hindcast_climatology_esp(minimal_emulator, tmp_path, salmon_meteo):
     }
 
     # Construct climpred HindcastEnsemble
-    qobs = xr.open_dataset(salmon_meteo).qobs
+    salmon_file = get_file(
+        "raven-gr4j-cemaneige/Salmon-River-Near-Prince-George_meteo_daily.nc"
+    )
+    qobs = xr.open_dataset(salmon_file).qobs
+
     qobs.name = "q_sim"
     hce = HindcastEnsemble(hc).add_observations(qobs)
 

--- a/tests/test_forecasting.py
+++ b/tests/test_forecasting.py
@@ -24,14 +24,14 @@ def test_warm_up(minimal_emulator, tmp_path):
 
 
 def test_climatology_esp(minimal_emulator, tmp_path):
-    config = minimal_emulator.copy()
+    config = minimal_emulator.model_copy(deep=True)
     esp = climatology_esp(config, workdir=tmp_path, years=[1955, 1956])
     np.testing.assert_array_equal(esp.storage.member, [1955, 1956])
     assert len(esp.hydrograph.time) == minimal_emulator.duration + 1
 
 
 def test_hindcast_climatology_esp(minimal_emulator, tmp_path, get_local_testdata):
-    config = minimal_emulator.copy()
+    config = minimal_emulator.model_copy(deep=True)
     hc = hindcast_climatology_esp(
         config,
         warm_up_duration=5,

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -1,3 +1,5 @@
+from shutil import copyfile
+
 import numpy as np
 import xarray as xr
 from xclim import set_options
@@ -7,11 +9,15 @@ from ravenpy.utilities import graphs
 
 
 class TestGraph:
-    def test_ts_fit_graph(self, get_local_testdata):
-        f = get_local_testdata(
+    def test_ts_fit_graph(self, get_local_testdata, tmp_path):
+        raven_hydrograph = get_local_testdata(
             "hydro_simulations/raven-gr4j-cemaneige-sim_hmets-0_Hydrographs.nc",
         )
-        with xr.open_dataset(f) as ds:
+        file = tmp_path / "raven-gr4j-cemaneige-sim_hmets-0_Hydrographs.nc"
+
+        copyfile(raven_hydrograph, file)
+
+        with xr.open_dataset(file) as ds:
             ts = stats(ds.q_sim, op="max", freq="M")
             with set_options(check_missing="skip"):
                 p = fit(ts)

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps =
 commands =
     # Regenerate NetCDF4-Python wheel from source files
     # Rebuild netcdf4 on Linux due to errors in new version (https://github.com/Unidata/netcdf4-python/issues/1192)
-    linux: python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir netcdf4==1.6.4 --no-binary netcdf4
+    # linux: python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir netcdf4==1.6.4 --no-binary netcdf4
     # Rebuild GDAL in order to gain access to GDAL system-level objects
     python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir gdal~={env:GDAL_VERSION} --no-binary gdal
     # Run tests

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ commands =
     # Rebuild netcdf4 on Linux due to errors in new version (https://github.com/Unidata/netcdf4-python/issues/1192)
     # linux: python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir netcdf4==1.6.4 --no-binary netcdf4
     # Rebuild GDAL in order to gain access to GDAL system-level objects
-    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir gdal~={env:GDAL_VERSION} --no-binary gdal
+    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir gdal=={env:GDAL_VERSION}.* --no-binary gdal
     # Run tests
     pytest --cov
     # Coveralls requires access to a repo token set in .coveralls.yml in order to report stats

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ commands =
     # Rebuild netcdf4 on Linux due to errors in new version (https://github.com/Unidata/netcdf4-python/issues/1192)
     linux: python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir netcdf4==1.6.4 --no-binary netcdf4
     # Rebuild GDAL in order to gain access to GDAL system-level objects
-    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir gdal=={env:GDAL_VERSION} --no-binary gdal
+    python -m pip install --upgrade --force-reinstall --no-deps --no-cache-dir gdal~={env:GDAL_VERSION} --no-binary gdal
     # Run tests
     pytest --cov
     # Coveralls requires access to a repo token set in .coveralls.yml in order to report stats


### PR DESCRIPTION
### Changes

- Added `h5netcdf` as a core dependency, acting as a backup engine for reading netcdf files.
- Made use of `model_copy(deep=True)` when dealing with Raven configs in the testing suite.
- Updated `autodoc-pydantic` for compatibility with `pydantic` v2.0+
- Modified some session-scoped `pytest` fixtures that were causing problems in other tests.
- Removed the redundant `emulators`-based `pytest` fixtures; These are now loaded from `emulators.py` in the `tests` folder.