### PR TITLE
Filter HRUs with unrecognized hru_type attribute

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,11 @@
 History
 =======
 
-0.13 (2023-01-10)
+0.14 (unreleased)
+----------------
+* Automatically filter HRUs based on the hru_type.
+
+0.13 (2024-01-10)
 -----------------
 * Fixed problem with scalar elevation in netCDF files parsed with `nc_specs` (issue #279, PR #323)
 * Added notebook on sensitivity analysis (PR #320)

--- a/ravenpy/config/base.py
+++ b/ravenpy/config/base.py
@@ -1,3 +1,4 @@
+import typing
 from enum import Enum
 from textwrap import dedent, indent
 from typing import Any, Dict, Optional, Sequence, Tuple, Union

--- a/ravenpy/config/commands.py
+++ b/ravenpy/config/commands.py
@@ -341,7 +341,7 @@ class HRUs(ListCommand):
 
         allowed.append(None)
 
-        out = [value for value in values if value.hru_type in allowed]
+        out = [value for value in values if getattr(value, "hru_type", None) in allowed]
         if len(out) != len(values):
             warnings.warn(
                 "HRUs with an unrecognized `hru_type` attribute were ignored."

--- a/ravenpy/config/emulators/hbvec.py
+++ b/ravenpy/config/emulators/hbvec.py
@@ -1,4 +1,5 @@
 from typing import Dict, Literal, Sequence, Union
+from warnings import warn
 
 from pydantic import Field, field_validator
 from pydantic.dataclasses import dataclass

--- a/ravenpy/config/utils.py
+++ b/ravenpy/config/utils.py
@@ -1,4 +1,5 @@
 import os
+import typing
 from typing import Optional, Sequence, Union
 
 import cf_xarray  # noqa: F401
@@ -179,3 +180,13 @@ def get_average_annual_runoff(
         q_year = np.mean(q_year)  # [mm/yr] mean over all years in record
 
     return q_year
+
+
+def get_annotations(a):
+    """Return all annotations inside [] or Union[...]."""
+
+    for arg in typing.get_args(a):
+        if typing.get_origin(arg) == Union:
+            yield from get_annotations(arg)
+        else:
+            yield arg

--- a/tests/test_rvs.py
+++ b/tests/test_rvs.py
@@ -120,3 +120,15 @@ def test_config(dummy_config):
     assert conf.model_config["populate_by_name"]
     # nt = cls(params=[0.5], Calendar="NOLEAP")
     # assert nt.air_snow_coeff == 0.5
+
+
+def test_hru_filter():
+    """Test that unrecognized HRU types are filtered out."""
+    from ravenpy.config.emulators.gr4jcn import LakeHRU
+    from ravenpy.config.emulators.hbvec import HRUs, LandHRU
+
+    with pytest.warns(UserWarning):
+        hrus = HRUs([LandHRU(), LandHRU(), LakeHRU()])
+
+    # The GR4J lake HRU is not part of the HBVEC config.
+    assert len(hrus.root) == 2


### PR DESCRIPTION
Should fix #340 

Adds a field validator on HRUs to ignore those with an hru_type that do not match expectations defined in the configuration. 

Emits a UserWarning if some HRUs are ignored. 