### PR TITLE
Open raven-hydro pin

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 -------------------
 * Add support for new processes and methods added in Raven v3.8.
 * Added support for Python 3.12 and dropped support for Python3.8.
-* Upgraded `raven-hydro` to v0.3.0 and `RavenHydroFramework` to v3.8.
+* Added support for `raven-hydro` v0.3.0 and `RavenHydroFramework` to v3.8.
 * `ravenpy` now requires `xclim` >= v0.48.2, `xarray` >= v2023.11.0, and `pandas` >= 2.2.0.
 
 Internal changes

--- a/environment-rtd.yml
+++ b/environment-rtd.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
   - python >=3.9,<3.10  # fixed to reduce solver time
-  - raven-hydro >=0.2.4
+  - raven-hydro >=0.2.4,<1.0
   - autodoc-pydantic
   - click
 #  - clisops  # mocked

--- a/environment-rtd.yml
+++ b/environment-rtd.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
   - python >=3.9,<3.10  # fixed to reduce solver time
-  - raven-hydro ==0.2.4  # FIXME: Update when raven-hydro 0.3.0 is available on conda-forge
+  - raven-hydro >=0.2.4
   - autodoc-pydantic
   - click
 #  - clisops  # mocked

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python >=3.9,<3.13
-  - raven-hydro ==0.2.4  # FIXME: Update when raven-hydro 0.3.0 is available on conda-forge
+  - raven-hydro >=0.2.4
   - libgcc  # for mixing raven-hydro from PyPI with conda environments
   - affine
   - black >=24.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python >=3.9,<3.13
-  - raven-hydro >=0.2.4
+  - raven-hydro >=0.2.4,<1.0
   - libgcc  # for mixing raven-hydro from PyPI with conda environments
   - affine
   - black >=24.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "platformdirs",
   "pydantic >=2.0",
   "pymbolic",
-  "raven-hydro >=0.2.4",
+  "raven-hydro >=0.2.4,<1.0",
   "requests",
   "scipy",
   "spotpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "platformdirs",
   "pydantic >=2.0",
   "pymbolic",
-  "raven-hydro ==0.3.0",
+  "raven-hydro >=0.2.4",
   "requests",
   "scipy",
   "spotpy",


### PR DESCRIPTION
### Changes

*  `raven-hydro >=0.2.4,<1.0` is now the supported version of the model package.

### Additional information

It is *very important* that the upper pin is placed on `raven-hydro` as we have older/obsolete versions in conda-forge that were pinned to the versions of `RavenHydroFramework`. We dropped this convention in order to have more granular control over the version string.

It's unclear to me how we can fix this versioning on conda-forge without breaking older packages, but it should be mentioned that the older packages of `RavenPy` are broken anyway (the build-engine based on `setuptools` relied on direct downloads of the model source code using URLs that are no longer valid; i.e. we can no longer install the older versions of `RavenPy` from `pip`).