### PR TITLE
Remove requests library, fix pyogrio calls, synchronize deps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+v0.16.0 (unreleased)
+--------------------
+
+* Set base required `geopandas` to v1.0.
+* Removed the pin on `pyogrio` (set by `geopandas` now).
+* Removed the `requests` dependency (now using `urllib`/`urllib3`).
+
 v0.15.0 (2024-06-20)
 --------------------
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - dask
   - fiona
   - gdal >=3.1
-  - geopandas >=0.14.0
+  - geopandas >=1.0
   - h5netcdf
   - haversine
   - isort >=5.13.2
@@ -29,13 +29,11 @@ dependencies:
   - pydantic >=2.0
   - pydap
   - pymbolic
-  - pyogrio # <0.8.0  # pyogrio 0.8.0 is not yet compatible with geopandas
-  - pyproj >=3.0
+  - pyproj >=3.3.0
   - rasterio
-  - requests
   - rioxarray
   - scipy >=1.10.0
-  - shapely
+  - shapely >=2.0.0
   - spotpy
   - statsmodels
   - typing_extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "haversine",
   "matplotlib",
   "netCDF4 <=1.6.5",
-  "numpy <2.0.0",
+  "numpy >=1.23,<2.0.0",
   "owslib >=0.29.1",
   "pandas >=2.2.0",
   "pint >=0.20,<0.24",
@@ -55,7 +55,6 @@ dependencies = [
   "pydap",
   "pymbolic",
   "raven-hydro >=0.3.1,<1.0",
-  "requests",
   "scipy",
   "spotpy",
   "statsmodels",
@@ -129,14 +128,13 @@ docs = [
 gis = [
   "affine",
   "fiona >=1.9",
-  "geopandas >=0.14.0",
+  "geopandas >=1.0",
   "gdal >=3.1",
   "lxml",
-  "pyogrio", # pyogrio 0.8.0 is not compatible with geopandas
-  "pyproj >=3.0.0",
+  "pyproj >=3.3.0",
   "rasterio",
   "rioxarray",
-  "shapely"
+  "shapely >=2.0"
 ]
 all = [
   "ravenpy[dev]",

--- a/src/ravenpy/utilities/testdata.py
+++ b/src/ravenpy/utilities/testdata.py
@@ -1,8 +1,10 @@
 """Tools for searching for and acquiring test data."""
 
 import hashlib
+import json
 import logging
 import re
+import urllib
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
@@ -12,7 +14,6 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin
 from urllib.request import urlretrieve
 
-import requests
 from platformdirs import user_cache_dir
 from xarray import Dataset
 from xarray import open_dataset as _open_dataset
@@ -254,8 +255,8 @@ def query_folder(
     repo_name = github_url.strip("https://github.com/")
 
     url = f"https://api.github.com/repos/{repo_name}/git/trees/{branch}?recursive=1"
-    r = requests.get(url)  # noqa: S113
-    res = r.json()
+    with urllib.request.urlopen(url) as response:  # noqa: S310
+        res = json.loads(response.read().decode())
 
     try:
         md5_files = [f["path"] for f in res["tree"] if f["path"].endswith(".md5")]

--- a/tests/test_geo_utilities.py
+++ b/tests/test_geo_utilities.py
@@ -259,7 +259,7 @@ class TestGenericGeoOperations:
             data = gt.read(1)  # read band 1 (red)
             assert data.min() == 0
             assert data.max() == 255
-            np.testing.assert_almost_equal(data.mean(), 60.73, 2)
+            np.testing.assert_almost_equal(data.mean(), 60.747, 3)
 
     def test_warped_raster_slope(self, tmp_path, get_local_testdata):
         reproj_file = tempfile.NamedTemporaryFile(
@@ -288,7 +288,7 @@ class TestGenericGeoOperations:
         aspect_grid = self.analysis.gdal_aspect_analysis(reproj_file)
 
         np.testing.assert_almost_equal(
-            self.analysis.circular_mean_aspect(aspect_grid), 7.78, decimal=2
+            self.analysis.circular_mean_aspect(aspect_grid), 7.7397, decimal=3
         )
 
     def test_raster_clip(self, tmp_path, get_local_testdata):

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -59,8 +59,7 @@ if os.getenv("CONDA_DEFAULT_ENV") == "raven-dev":
         region_url = self.geoserver.filter_hydrobasins_attributes_wfs(
             attribute="MAIN_BAS", value=main_bas, domain="na"
         )
-        with urllib.request.urlopen(url=region_url) as req:
-            gdf = self.gpd.read_file(filename=req, engine="pyogrio")
+        gdf = self.gpd.read_file(filename=region_url, engine="pyogrio")
 
         assert len(gdf) == 18
         assert gdf.crs.to_epsg() == 4326
@@ -117,9 +116,7 @@ class TestHydroRouting:
         region_url = self.geoserver.filter_hydro_routing_attributes_wfs(
             attribute="IsLake", value="1.0", lakes="1km", level="07"
         )
-        with urllib.request.urlopen(url=region_url) as req:
-            gdf = self.gpd.read_file(filename=req, engine="pyogrio")
-
+        gdf = self.gpd.read_file(filename=region_url, engine="pyogrio")
         assert len(gdf) == 11415
 
     @pytest.mark.slow


### PR DESCRIPTION
FYI @tlvu

### Changes

- Removed the pin on `pyogrio` (set by `geopandas` now).
- Set base required `geopandas` to v1.0.
- Updated remote requests code to rely on `urllib{3}` instead of `requests`.
- Updated calls to remote GeoJSON file-like objects.