### PR TITLE
Fix matplotlib call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,9 @@ Changelog
 v0.17.0 (unreleased)
 --------------------
 
-* Updated the cookiecutter template to the latest commit and synchronized dependencies between PyPI and Anaconda recipes. (PR #427).
-* Updated `ts_fit_graph` logic for `matplotlib` >= 3.10.0 compatibility. (PR #434).
+* Updated the cookiecutter template to the latest commit and synchronized dependencies between PyPI and Anaconda recipes. (PR #427)
+* Updated `ts_fit_graph` logic for `matplotlib` >= 3.10.0 compatibility. (PR #434)
+* Temporarily pinned `pygments` below v2.19 due to a breaking change affecting `sphinx-codeautolink`. (PR #434)
 
 v0.16.1 (2024-12-05)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ v0.17.0 (unreleased)
 --------------------
 
 * Updated the cookiecutter template to the latest commit and synchronized dependencies between PyPI and Anaconda recipes. (PR #427).
-* Updated `ts_fit_graph` logic for `matplotlib` >= 3.10.0 compatibility.
+* Updated `ts_fit_graph` logic for `matplotlib` >= 3.10.0 compatibility. (PR #434).
 
 v0.16.1 (2024-12-05)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v0.17.0 (unreleased)
 --------------------
 
 * Updated the cookiecutter template to the latest commit and synchronized dependencies between PyPI and Anaconda recipes. (PR #427).
+* Updated `ts_fit_graph` logic for `matplotlib` >= 3.10.0 compatibility.
 
 v0.16.1 (2024-12-05)
 --------------------

--- a/environment-rtd.yml
+++ b/environment-rtd.yml
@@ -25,7 +25,7 @@ dependencies:
   - notebook
   - pandoc
   - pydantic >=2.0
-  - pygments
+  - pygments <2.19 # FIXME: Newest pygments breaks sphinx-codeautolink. See: https://github.com/felix-hilden/sphinx-codeautolink/issues/153
   - salib
   - seaborn
   - sphinx >=7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ docs = [
   "myst_nb",
   "nbsphinx",
   "numpydoc >=1.8.0",
-  "pygments",
+  "pygments <2.19", # FIXME: Newest pygments breaks sphinx-codeautolink. See: https://github.com/felix-hilden/sphinx-codeautolink/issues/153
   "pymetalink >=6.5.2",
   "salib",
   "s3fs",

--- a/src/ravenpy/utilities/graphs.py
+++ b/src/ravenpy/utilities/graphs.py
@@ -351,7 +351,6 @@ def ts_fit_graph(ts: xr.DataArray, params: xr.DataArray) -> matplotlib.pyplot.Fi
             t,
             alpha=0.5,
             bins=bins,
-            facecolor=(1, 1, 1),
             edgecolor="grey",
             linewidth=1,
         )

--- a/src/ravenpy/utilities/graphs.py
+++ b/src/ravenpy/utilities/graphs.py
@@ -343,13 +343,12 @@ def ts_fit_graph(ts: xr.DataArray, params: xr.DataArray) -> matplotlib.pyplot.Fi
             t,
             alpha=0.5,
             density=True,
-            edgecolor="grey",
             bins="auto",
             label="__nolabel__",
         )
         ax2.hist(
             t,
-            alpha=0.5,
+            facecolor="none",
             bins=bins,
             edgecolor="grey",
             linewidth=1,
@@ -364,7 +363,6 @@ def ts_fit_graph(ts: xr.DataArray, params: xr.DataArray) -> matplotlib.pyplot.Fi
 
         ps = ", ".join([f"{x:.1f}" for x in p.values])
         ax.plot(q, pdf, "-", label=f"{params.attrs['scipy_dist']}({ps})")
-        ax.set_zorder(2.5)
 
         # Labels
         ax.set_xlabel(f"{ts.long_name} (${units2pint(ts.units):~P}$)")

--- a/src/ravenpy/utilities/graphs.py
+++ b/src/ravenpy/utilities/graphs.py
@@ -330,7 +330,7 @@ def ts_fit_graph(ts: xr.DataArray, params: xr.DataArray) -> matplotlib.pyplot.Fi
 
     fig, axes = plt.subplots(n, figsize=(10, 6), squeeze=False)
     if params.isnull().any():
-        raise ValueError("Null values in `params`.")
+        raise ValueError("Null values found in `params`.")
 
     for i in range(n):
         ax = axes.flat[i]
@@ -343,14 +343,16 @@ def ts_fit_graph(ts: xr.DataArray, params: xr.DataArray) -> matplotlib.pyplot.Fi
             t,
             alpha=0.5,
             density=True,
+            edgecolor="grey",
             bins="auto",
             label="__nolabel__",
         )
         ax2.hist(
             t,
+            alpha=0.5,
             bins=bins,
-            facecolor=(1, 1, 1, 0.01),
-            edgecolor="gray",
+            facecolor=(1, 1, 1),
+            edgecolor="grey",
             linewidth=1,
         )
 
@@ -362,7 +364,8 @@ def ts_fit_graph(ts: xr.DataArray, params: xr.DataArray) -> matplotlib.pyplot.Fi
         pdf = dc.pdf(q)
 
         ps = ", ".join([f"{x:.1f}" for x in p.values])
-        ax.plot(q, pdf, "-", label="{}({})".format(params.attrs["scipy_dist"], ps))
+        ax.plot(q, pdf, "-", label=f"{params.attrs['scipy_dist']}({ps})")
+        ax.set_zorder(2.5)
 
         # Labels
         ax.set_xlabel(f"{ts.long_name} (${units2pint(ts.units):~P}$)")

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -1,7 +1,7 @@
 from shutil import copyfile
 
 import numpy as np
-import xarray as xr
+from xarray import open_dataset
 from xclim import set_options
 from xclim.indicators.generic import fit, stats
 
@@ -17,7 +17,7 @@ class TestGraph:
 
         copyfile(raven_hydrograph, file)
 
-        with xr.open_dataset(file) as ds:
+        with open_dataset(file) as ds:
             ts = stats(ds.q_sim, op="max", freq="ME")
             with set_options(check_missing="skip"):
                 p = fit(ts)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Fixes a `matplotlib` for v3.10+ compatibility.
* Pins `pygments` to avoid a breaking change affecting `sphinx-codeautolink`

### Does this PR introduce a breaking change?

No.

### Other information:

It's not entirely clear to me whether the dual histograms are being drawn properly to begin with. Alpha values from `ax` are the only ones that seem to matter when examining the graphic generated during tests.