### PR TITLE
Do not attempt to represent models due to non-serializable errors

### DIFF
--- a/src/ravenpy/config/emulators/__init__.py
+++ b/src/ravenpy/config/emulators/__init__.py
@@ -9,26 +9,18 @@ from ravenpy.config.emulators.routing import BasicRoute
 from ravenpy.config.emulators.sacsma import SACSMA
 
 __all__ = [
-    "GR4JCN",
-    "HBVEC",
-    "HMETS",
-    "HYPR",
-    "SACSMA",
-    "BasicRoute",
-    "Blended",
-    "CanadianShield",
-    "Mohyse",
     "get_model",
 ]
 
 
 def get_model(name):
-    """Return the corresponding Raven emulator configuration class.
+    """
+    Return the corresponding Raven emulator configuration class.
 
     Parameters
     ----------
     name : str
-      Model class name or model identifier.
+        Model class name or model identifier.
 
     Returns
     -------


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Removes the `pydantic`-defined models from the public API of `emulators`.

### Does this PR introduce a breaking change?

No. Usage still works, but documentation should be different.

### Other information:

The issue appears to be brought on because the `ListCommand` class can't serialize what `root` is when generating the documentation:

```python
lass ListCommand(RootModel, _Command):
    """Use so that commands with __root__: Sequence[Command] behave like a list."""

    root: Sequence[Any]

    def __iter__(self):
        return iter(self.root)

    def __getitem__(self, item):
        return self.root[item]

    def __len__(self):
        return len(self.root)

    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
```

This means that any emulated models built using it are raising errors when trying to parse the documentation. I'm not familiar enough with `pydantic` to understand how to fix this, so I'm removing them from the docs to see if that fixes things.