### PR TITLE
Disable PDF generation on ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,8 +22,8 @@ build:
       - sphinx-build -M gettext docs docs/_build
       - sphinx-build -b linkcheck docs/ _build/linkcheck || true
 
-formats:
-  - pdf
+# FIXME: PDF builds not working since addition of the RavenPy logo
+formats: [ ]
 
 conda:
   environment: environment-docs.yml


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Disable PDF generation

### Does this PR introduce a breaking change?

No.

### Other information:

The `latest` and `stable` builds of the documentation will try to build a PDF using LaTeX, and unfortunately it isn't clear why this is failing. There's likely a workaround that we can port from `xscen` or `xclim` to get it working again, but, in the meantime, we want the docs to be web-accessible at the very least.