### PR TITLE
Set default station_idx to None for ReadFromNetCDF

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,9 @@
 Changelog
 =========
 
-
 v0.18.3 (unreleased)
 --------------------
-* Fix bug affecting GriddedForcing, where `station_idx` in the call to `nc_specs` was set to 1 instead of None. (#PR #501)
+* Fix bug affecting GriddedForcing, where `station_idx` in the call to `nc_specs` was set to ``1`` instead of ``None``. (#PR #501)
 
 v0.18.2 (2025-05-05)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+
+v0.18.3 (unreleased)
+--------------------
+* Fix bug affecting GriddedForcing, where `station_idx` in the call to `nc_specs` was set to 1 instead of None. (#PR #501)
+
 v0.18.2 (2025-05-05)
 --------------------
 

--- a/src/ravenpy/config/commands.py
+++ b/src/ravenpy/config/commands.py
@@ -897,7 +897,7 @@ class ReadFromNetCDF(FlatCommand):
 
     @classmethod
     def from_nc(
-        cls, fn, data_type, station_idx=1, alt_names=(), engine="h5netcdf", **kwds
+        cls, fn, data_type, station_idx=None, alt_names=(), engine="h5netcdf", **kwds
     ):
         """Instantiate class from netCDF dataset."""
         specs = nc_specs(
@@ -1115,10 +1115,10 @@ class Gauge(FlatCommand):
             for dtype in forcings:
                 try:
                     specs = nc_specs(
-                        f,
-                        dtype,
-                        idx,
-                        alt_names.get(dtype, ()),
+                        fn=f,
+                        data_type=dtype,
+                        station_idx=idx,
+                        alt_names=alt_names.get(dtype, ()),
                         mon_ave=mon_ave,
                         engine=engine,
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ def populate_testing_data(
             "eccc_forecasts/geps_watershed.nc",
             "cmip5/nasa_nex-gddp-1.0_day_inmcm4_historical+rcp45_nex-gddp_1971-1972_subset.nc",
             "cmip5/nasa_nex-gddp-1.0_day_inmcm4_historical+rcp85_nex-gddp_2070-2071_subset.nc",
+            "cmip5/tas_Amon_CanESM2_rcp85_r1i1p1_200601-210012_subset.nc",
             "famine/famine_input.nc",
             "gr4j_cemaneige/solution.rvc",
             "hydro_simulations/raven-gr4j-cemaneige-sim_hmets-0_Hydrographs.nc",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -400,13 +400,18 @@ def test_station_forcing(get_local_testdata):
 def test_gridded_forcing(get_local_testdata):
     """TODO: Make sure dimensions are in the order x, y, t."""
     fn = get_local_testdata("raven-routing-sample/VIC_temperatures.nc")
-
     rc.GriddedForcing.from_nc(fn, data_type="TEMP_AVE", alt_names=("Avg_temp",))
-    # assert gf.dim_names_nc == ("lon", "lat", "time")
+    # assert gf.dim_names_nc == ("lon_dim", "lat_dim", "time")
 
     fn = get_local_testdata("raven-routing-sample/VIC_streaminputs.nc")
     rc.GriddedForcing.from_nc(fn, data_type="PRECIP", alt_names=("Streaminputs",))
     # assert gf.dim_names_nc == ("lon_dim", "lat_dim", "time")
+
+    fn = get_local_testdata(
+        "cmip5/tas_Amon_CanESM2_rcp85_r1i1p1_200601-210012_subset.nc"
+    )
+    gf = rc.GriddedForcing.from_nc(fn, data_type="TEMP_AVE", engine="netcdf4")
+    assert gf.latitude_var_name_nc is None
 
 
 def test_gauge(get_local_testdata, tmp_path):


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #500
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Bad default value for station_idx in the case of GriddedForcing.from_nc. 

### Does this PR introduce a breaking change?
Yes, this changes the default value for station_idx for ReadFromNetCDF. No test broke, so typical usage should not change.

### Other information:
