### PR TITLE
Cookiecutter update

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/Ouranosinc/cookiecutter-pypackage",
-  "commit": "b9bacb7ddbbfaa8eff8c3e0182ebf2e8a66d00c7",
+  "commit": "cb8b26cb78a428f6ce447a0ab1b08c0c171ad5aa",
   "context": {
     "cookiecutter": {
       "full_name": "David Huard",
@@ -22,7 +22,7 @@
       "generated_with_cruft": "y",
       "__gh_slug": "https://github.com/CSHS-CWRA/RavenPy",
       "_template": "https://github.com/Ouranosinc/cookiecutter-pypackage",
-      "_commit": "b9bacb7ddbbfaa8eff8c3e0182ebf2e8a66d00c7"
+      "_commit": "cb8b26cb78a428f6ce447a0ab1b08c0c171ad5aa"
     }
   },
   "directory": null,

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -2,8 +2,9 @@
 # - Contents: Read and Write
 # - Metadata: Read-Only
 # - Pull Requests: Read and Write
+# This workflow also requires a dedicated environment to ensure that credentials are safely accessed ("automation").
 
-name: "Bump Patch Version"
+name: "Bump Version"
 
 on:
   push:
@@ -42,7 +43,9 @@ permissions:
 
 jobs:
   bump_patch_version:
+    name: Bump build/patch version
     runs-on: ubuntu-latest
+    environment: automation
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           python -m tox -e lint
 
   pip:
-    name: Test with Python${{ matrix.python-version }} (tox, ${{ matrix.os }}), upstream=${{ matrix.upstream-branch }})
+    name: Test with Python${{ matrix.python-version }} (tox, ${{ matrix.os }}), raven-hydro=${{ matrix.raven-hydro-upstream-branch }})
     needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
@@ -67,6 +67,7 @@ jobs:
         include:
           - os: 'ubuntu-latest'
             python-version: '3.10'
+            raven-hydro-upstream-branch: "main"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -126,7 +127,7 @@ jobs:
             python3 -m tox
         env:
           TOX_GH_MAJOR_MINOR: ${{ matrix.python-version }}
-          UPSTREAM_BRANCH: ${{ matrix.upstream-branch }}
+          RAVEN_HYDRO_UPSTREAM_BRANCH: ${{ matrix.raven-hydro-upstream-branch }}
 
       - name: Report Coverage
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,5 @@
+# This workflow requires a dedicated environment to ensure that credentials are safely accessed ("automation").
+
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.
@@ -23,6 +25,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    environment: automation
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -27,15 +27,14 @@ jobs:
           persist-credentials: false
 
       - name: Create Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # 2.6.1
         env:
-          # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          draft: true
-          prerelease: false
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "$REF_NAME" \
+            --title "$REF_NAME" \
+            --draft \
+            --notes ""
 
   build-n-publish-testpypi:
     name: Build and publish Python 🐍 distributions 📦 to TestPyPI

--- a/.github/workflows/workflow-warning.yml
+++ b/.github/workflows/workflow-warning.yml
@@ -32,48 +32,60 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
 
-      - name: Find Warning Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: fc_warning
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: |
-            This Pull Request modifies GitHub workflows and is coming from a fork.
+      - name: Manage Warning / Note Comments
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'approved') }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          WARNING_TEXT="This Pull Request modifies GitHub workflows and is coming from a fork."
+          NOTE_TEXT="Workflow changes in this Pull Request have been approved!"
 
-      - name: Create Warning Comment
-        if: |
-          (steps.fc_warning.outputs.comment-id == '') &&
-          (!contains(github.event.pull_request.labels.*.name, 'approved')) &&
-          (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          comment-id: ${{ steps.fc_warning.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            > [!WARNING]
-            > This Pull Request modifies GitHub Workflows and is coming from a fork.
-            **It is very important for the reviewer to ensure that the workflow changes are appropriate.**
-          edit-mode: replace
+          # Fetch existing comments
+          COMMENTS=$(gh api repos/$REPO/issues/$PR_NUMBER/comments)
 
-      - name: Find Note Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: fc_note
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Workflow changes in this Pull Request have been approved!
+          # Find warning comment ID
+          WARNING_COMMENT_ID=$(echo "$COMMENTS" | jq -r \
+            '.[] | select(.user.login=="github-actions[bot]") | select(.body | contains("'"$WARNING_TEXT"'")) | .id' | head -n 1)
 
-      - name: Update Comment
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'approved')
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          comment-id: ${{ steps.fc_note.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            > [!NOTE]
-            > Workflow changes in this Pull Request have been approved!
-          reactions: |
-            hooray
-          edit-mode: append
+          # Find note comment ID
+          NOTE_COMMENT_ID=$(echo "$COMMENTS" | jq -r \
+            '.[] | select(.user.login=="github-actions[bot]") | select(.body | contains("'"$NOTE_TEXT"'")) | .id' | head -n 1)
+
+          if [ "$APPROVED" = "true" ]; then
+            BODY="> [!NOTE]
+          > Workflow changes in this Pull Request have been approved!"
+
+            if [ -n "$NOTE_COMMENT_ID" ] && [ "$NOTE_COMMENT_ID" != "null" ]; then
+              # Append to existing note comment
+              EXISTING=$(gh api repos/$REPO/issues/comments/$NOTE_COMMENT_ID --jq .body)
+              gh api \
+                --method PATCH \
+                repos/$REPO/issues/comments/$NOTE_COMMENT_ID \
+                -f body="$EXISTING
+
+          $BODY"
+            else
+              # Create new note comment
+              gh pr comment "$PR_NUMBER" --body "$BODY"
+            fi
+
+            # Add reaction (hooray)
+            if [ -n "$NOTE_COMMENT_ID" ] && [ "$NOTE_COMMENT_ID" != "null" ]; then
+              gh api \
+                --method POST \
+                repos/$REPO/issues/comments/$NOTE_COMMENT_ID/reactions \
+                -f content='hooray' \
+                -H "Accept: application/vnd.github+json"
+            fi
+
+          else
+            BODY="> [!WARNING]
+          > This Pull Request modifies GitHub Workflows and is coming from a fork.
+          **It is very important for the reviewer to ensure that the workflow changes are appropriate.**"
+
+            if [ -z "$WARNING_COMMENT_ID" ] || [ "$WARNING_COMMENT_ID" = "null" ]; then
+              gh pr comment "$PR_NUMBER" --body "$BODY"
+            fi
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.10
     hooks:
       - id: ruff-check
         args: [ '--fix', '--show-fixes' ]
@@ -97,12 +97,12 @@ repos:
       - id: check-github-workflows
       - id: check-readthedocs
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.23.1
+    rev: v1.24.1
     hooks:
       - id: zizmor
         args: [ '--config=.zizmor.yml' ]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
+    rev: v8.30.1
     hooks:
       - id: gitleaks
   - repo: meta

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -4,3 +4,7 @@ rules:
       - label.yml:9
       - first-pull-request.yml:3
       - workflow-warning.yml:3
+  superfluous-actions:
+    ignore:
+      - testdata-version.yml:69
+      - testdata-version.yml:85

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,19 +2,22 @@
 Changelog
 =========
 
-..
-    `Unreleased <https://github.com/CSHS-CWRA/RavenPy>`_ (latest)
-    -------------------------------------------------------------
+`Unreleased <https://github.com/CSHS-CWRA/RavenPy>`_ (latest)
+-------------------------------------------------------------
 
-    Contributors:
+Contributors: Trevor James Smith (:user:`Zeitsperre`).
 
-    Changes
-    ^^^^^^^
-    * No change.
+Internal changes
+^^^^^^^^^^^^^^^^
+* Updates the cookiecutter template. (PR #600):
+    * Dependencies have been updated and synchronized,
+    * `h5py` is no longer explitily reinstalled when running tests via `tox`.
+    * New `io` dependency-group for managing common file read/write libraries.
+* Upstream `raven-hydro` versions are now installed in `tox` via the `RAVEN_HYDRO_UPSTREAM_BRANCH` environment variable. (PR #600)
 
-    Fixes
-    ^^^^^
-    * No change.
+Fixes
+^^^^^
+* `tox-gh` now fully supports Python3.14. (PR #600)
 
 .. _changes_0.21.0:
 

--- a/CI/requirements_ci.in
+++ b/CI/requirements_ci.in
@@ -1,4 +1,4 @@
-bump-my-version==1.2.6
+bump-my-version==1.3.0
 deptry==0.25.1
 exceptiongroup==1.3.1
 flit==3.12.0
@@ -6,5 +6,5 @@ pip==26.0.1
 pydantic==2.12.5
 pylint==4.0.5
 tomli==2.4.0
-tox==4.50.3
+tox==4.52.0
 tox-gh==1.7.1

--- a/CI/requirements_ci.txt
+++ b/CI/requirements_ci.txt
@@ -20,10 +20,10 @@ bracex==2.4 \
     --hash=sha256:a27eaf1df42cf561fed58b7a8f3fdf129d1ea16a81e1fadd1d17989bc6384beb \
     --hash=sha256:efdc71eff95eaff5e0f8cfebe7d01adf2c8637c8c92edaf63ef348c241a82418
     # via wcmatch
-bump-my-version==1.2.6 \
-    --hash=sha256:1f2f0daa5d699904e9739be8efb51c4c945461bad83cd4da4c89d324d9a18343 \
-    --hash=sha256:a2f567c10574a374b81a9bd6d2bd3cb2ca74befe5c24c3021123773635431659
-    # via -r requirements_ci.in
+bump-my-version==1.3.0 \
+    --hash=sha256:3cdaa54588d2443a29303b77e7539417187952c3d22f87bfdd32c0fe6af2f570 \
+    --hash=sha256:5780137a8d93378af3839798fcba01c7e6cb28dcc5aa5a7ab4d8507787f1995c
+    # via -r CI/requirements_ci.in
 cachetools==7.0.5 \
     --hash=sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990 \
     --hash=sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114
@@ -155,7 +155,7 @@ deptry==0.25.1 \
     --hash=sha256:df88952a2bab7517ef23cb304b979199b28449e5d9db2e9ba9bc27a286ac852b \
     --hash=sha256:e3fa3321078e11cd1ac3f10ce3ff0547731c53f9253b87c757a8749c76fe8fa9 \
     --hash=sha256:e6f7b8fa72932e51e86799b10dcd29381b2132dc799c790dca3b28ab08dffb28
-    # via -r requirements_ci.in
+    # via -r CI/requirements_ci.in
 dill==0.3.9 \
     --hash=sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a \
     --hash=sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c
@@ -172,7 +172,7 @@ exceptiongroup==1.3.1 \
     --hash=sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219 \
     --hash=sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
     # via
-    #   -r requirements_ci.in
+    #   -r CI/requirements_ci.in
     #   anyio
 filelock==3.25.2 \
     --hash=sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694 \
@@ -184,7 +184,7 @@ filelock==3.25.2 \
 flit==3.12.0 \
     --hash=sha256:1c80f34dd96992e7758b40423d2809f48f640ca285d0b7821825e50745ec3740 \
     --hash=sha256:2b4e7171dc22881fa6adc2dbf083e5ecc72520be3cd7587d2a803da94d6ef431
-    # via -r requirements_ci.in
+    # via -r CI/requirements_ci.in
 flit-core==3.12.0 \
     --hash=sha256:18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2 \
     --hash=sha256:e7a0304069ea895172e3c7bb703292e992c5d1555dd1233ab7b5621b5b69e62c
@@ -252,7 +252,7 @@ pydantic==2.12.5 \
     --hash=sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49 \
     --hash=sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d
     # via
-    #   -r requirements_ci.in
+    #   -r CI/requirements_ci.in
     #   bump-my-version
     #   pydantic-settings
 pydantic-core==2.41.5 \
@@ -389,7 +389,7 @@ pygments==2.20.0 \
 pylint==4.0.5 \
     --hash=sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2 \
     --hash=sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c
-    # via -r requirements_ci.in
+    # via -r CI/requirements_ci.in
 pyproject-api==1.10.0 \
     --hash=sha256:40c6f2d82eebdc4afee61c773ed208c04c19db4c4a60d97f8d7be3ebc0bbb330 \
     --hash=sha256:8757c41a79c0f4ab71b99abed52b97ecf66bd20b04fa59da43b5840bac105a09
@@ -397,7 +397,9 @@ pyproject-api==1.10.0 \
 python-discovery==1.2.1 \
     --hash=sha256:180c4d114bff1c32462537eac5d6a332b768242b76b69c0259c7d14b1b680c9e \
     --hash=sha256:b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502
-    # via virtualenv
+    # via
+    #   tox
+    #   virtualenv
 python-dotenv==1.0.1 \
     --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
     --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
@@ -477,7 +479,7 @@ tomli==2.4.0 \
     --hash=sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa \
     --hash=sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087
     # via
-    #   -r requirements_ci.in
+    #   -r CI/requirements_ci.in
     #   deptry
     #   pylint
     #   pyproject-api
@@ -494,16 +496,16 @@ tomlkit==0.13.0 \
     # via
     #   bump-my-version
     #   pylint
-tox==4.50.3 \
-    --hash=sha256:5e788a512bfe6f7447e0c8d7c1b666eb2e56e5e676c65717490423bec37d1a07 \
-    --hash=sha256:c745641de6cc4f19d066bd9f98c1c25f7affb005b381b7f3694a1f142ea0946b
+tox==4.52.0 \
+    --hash=sha256:6054abf5c8b61d58776fbec991f9bf0d34bb883862beb93d2fe55601ef3977c9 \
+    --hash=sha256:624d8ea4a8c6d5e8d168eedf0e318d736fb22e83ca83137d001ac65ffdec46fd
     # via
-    #   -r requirements_ci.in
+    #   -r CI/requirements_ci.in
     #   tox-gh
 tox-gh==1.7.1 \
     --hash=sha256:4f4871ee4091b41464f2df9ab1fcedb14a48accdecbb60d53297301a9d8984c6 \
     --hash=sha256:a82285b16a597516f9a24f20326b124ddc7924a8b70cb05a9192e1c53d7f701d
-    # via -r requirements_ci.in
+    # via -r CI/requirements_ci.in
 types-setuptools==75.8.0.20250110 \
     --hash=sha256:96f7ec8bbd6e0a54ea180d66ad68ad7a1d7954e7281a710ea2de75e355545271 \
     --hash=sha256:a9f12980bbf9bcdc23ecd80755789085bad6bfce4060c2275bc2b4ca9f2bc480

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,6 +12,7 @@ dependencies:
   - climpred >=2.6.0
   - dask >=2024.8.1
   - h5netcdf >=1.3.0
+  - h5py
   - haversine >=2.8.0
   - matplotlib-base >=3.6.0
   - numpy >=1.25.0
@@ -33,16 +34,16 @@ dependencies:
   - zarr
   # Dev tools and testing
   - pip >=26.0.1
-  - bump-my-version >=1.2.6
+  - bump-my-version >=1.3.0
   - click >=8.3.1
-  - codespell >=2.4.1
+  - codespell >=2.4.2
   - coverage >=7.5.0
-  - deptry >=0.24.0
+  - deptry >=0.25.1
   - filelock >=3.14.0
   - flake8 >=7.3.0
   - flake8-rst-docstrings >=0.4.0
   - flit >=3.11.0,<4.0
-  - mypy >=1.19.1
+  - mypy >=1.20.0
   - numpydoc >=1.10.0
   - pooch >=1.8.0
   - prek >=0.3.0
@@ -50,9 +51,9 @@ dependencies:
   - pytest >=9.0.2
   - pytest-cov >=7.0.0
   - pytest-xdist >=3.2.0
-  - ruff >=0.15.0
-  - tox >=4.41.0
-  - tox-gh >=1.6.1
+  - ruff >=0.15.9
+  - tox >=4.52.0
+  - tox-gh >=1.7.1
   - vulture >=2.14
   - watchdog >=6.0.0
   # GIS support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,7 +283,7 @@ prek = "prek"
 tox-gh = "tox_gh"
 
 [tool.deptry.per_rule_ignores]
-DEP002 = ["h5netcdf"]
+DEP002 = ["h5netcdf", "h5py"]
 DEP004 = ["holoviews", "hvplot", "pooch"]
 
 [tool.flit.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,22 @@ build-backend = "flit_core.buildapi"
 [dependency-groups]
 lint = [
   # Linting tools
-  "codespell >=2.4.1",
-  "deptry >=0.24.0",
+  "codespell >=2.4.2",
+  "deptry >=0.25.1",
   "flake8 >=7.3.0",
   "flake8-rst-docstrings >=0.4.0",
-  "mypy >=1.19.1",
+  "mypy >=1.20.0",
   "numpydoc >=1.10.0",
   "pylint >=4.0.4",
-  "ruff >=0.15.0",
+  "ruff >=0.15.9",
   "vulture >=2.14",
   "yamllint >=1.38.0"
+]
+io = [
+  "h5netcdf",
+  "h5py",
+  "pooch >=1.8.0",
+  "zarr"
 ]
 test = [
   # Base testing support
@@ -25,7 +31,8 @@ test = [
   "pydap >=3.5.6",
   "pytest >=9.0.2",
   "pytest-cov >=7.0.0",
-  "pytest-xdist >=3.2.0"
+  "pytest-xdist >=3.2.0",
+  {include-group = "io"}
 ]
 notebooks = [
   "birdhouse-birdy >=0.9.1",
@@ -53,7 +60,7 @@ notebooks = [
   "xesmf",
   "xsdba >=0.4.0",
   "xskillscore >=0.0.29",
-  "zarr"
+  {include-group = "io"}
 ]
 docs = [
   # Documentation and example support
@@ -64,7 +71,7 @@ docs = [
   "matplotlib >=3.7.0",
   "myst_nb",
   "nbsphinx >=0.9.8",
-  "sphinx >=8.0.0",
+  "sphinx >=8.2.0",
   "sphinx-click",
   "sphinx-codeautolink >=0.16.2",
   "sphinx-copybutton >=0.5.2",
@@ -72,12 +79,12 @@ docs = [
   "sphinxcontrib-svg2pdfconverter >=1.2.3"
 ]
 tox = [
-  "tox >=4.41.0",
-  "tox-gh >=1.6.1"
+  "tox >=4.52.0",
+  "tox-gh >=1.7.1"
 ]
 dev = [
   # Development and testing tools
-  "bump-my-version >=1.2.6",
+  "bump-my-version >=1.3.0",
   "pip >=26.0.1",
   "prek >=0.3.0",
   "watchdog >=6.0.0",
@@ -129,7 +136,8 @@ dependencies = [
   "click >=8.3.1",
   "climpred >=2.6.0",
   "filelock >=3.14.0",
-  "h5netcdf >=1.5.0",
+  "h5netcdf",
+  "h5py",
   "haversine >=2.8.0",
   "matplotlib >=3.6.0",
   "numpy >=1.25.0",

--- a/tox.toml
+++ b/tox.toml
@@ -1,6 +1,6 @@
 envlist = [
   "lint",
-  "py3.{10,11,12,13,14}",
+  {product = [{prefix = "py3.", start = 10, stop = 14}]},
   "docs"
 ]
 skip_missing_interpreters = true
@@ -22,7 +22,6 @@ deps = ["numpy >= 1.25.0", "gdal == {env:GDAL_VERSION}.*", "setuptools >= 71.0"]
 extras = ["gis", "raven-hydro"]
 commands = [
   ["python", "-m", "pip", "install", "--no-user", "--upgrade", "--force-reinstall", "--no-deps", "--no-binary", "gdal", "gdal[numpy]=={env:GDAL_VERSION}.*"],
-  ["python", "-m", "pip", "install", "--no-user", "--upgrade", "--force-reinstall", "--no-deps", "--no-binary", "h5py", "h5py>=3.12.1"],
   ["python", "-c", "import ravenpy.testing.utils as rtu; rtu.populate_testing_data(branch=\"{env:RAVEN_TESTDATA_BRANCH}\")"],
   ["pytest", "{posargs}"]
 ]
@@ -60,7 +59,6 @@ commands_pre = [
   ["python", "-m", "pip", "check"]
 ]
 commands = [
-  ["python", "-m", "pip", "install", "--no-user", "--upgrade", "--force-reinstall", "--no-deps", "--no-binary", "h5py", "h5py>=3.12.1"],
   ["python", "-c", "import ravenpy.testing.utils as rtu; rtu.populate_testing_data(branch=\"{env:RAVEN_TESTDATA_BRANCH}\")"],
   ["pytest", "{posargs}"]
 ]

--- a/tox.toml
+++ b/tox.toml
@@ -38,22 +38,17 @@ commands = [
 commands_post = []
 allowlist_externals = ["make"]
 
-[env.upstream]
-description = "Run tests with pytest under {basepython} for upstream libraries"
-commands_pre = [
-  ["python", "-m", "pip", "list"],
-  ["python", "-m", "pip", "check"],
-  ["python", "-m", "pip", "install", "--no-user", "--upgrade", "--force-reinstall", "--no-deps", "--no-binary", "raven-hydro", "git+https://github.com/Ouranosinc/raven-hydro.git@{env:UPSTREAM_BRANCH}"]
-]
-
 [env_run_base]
 description = "Run tests with pytest under {basepython}"
-setenv = {PYTEST_ADDOPTS = "--color=yes --numprocesses=logical --durations=10 --cov=ravenpy --cov-report=lcov", PYTHONPATH = "{toxinidir}", TOX = "{envname}", UPSTREAM_BRANCH = "main"}
-passenv = ["CI", "COVERALLS_*", "GDAL_VERSION", "GITHUB_*", "LD_LIBRARY_PATH", "RAVEN_*", "UPSTREAM_BRANCH"]
+setenv = {PYTEST_ADDOPTS = "--color=yes --numprocesses=logical --durations=10 --cov=ravenpy --cov-report=lcov", PYTHONPATH = "{toxinidir}", TOX = "{envname}"}
+passenv = ["CI", "COVERALLS_*", "GDAL_VERSION", "GITHUB_*", "LD_LIBRARY_PATH", "RAVEN_*"]
 download = true
 install_command = ["python", "-m", "pip", "install", "--no-user", "{opts}", "{packages}"]
 dependency_groups = ["test"]
 extras = ["raven-hydro"]
+deps = [
+  {replace = "if", condition = "env.RAVEN_HYDRO_UPSTREAM_BRANCH", then = ["git+https://github.com/Ouranosinc/raven-hydro.git@{env:RAVEN_HYDRO_UPSTREAM_BRANCH}"], extend = true}
+]
 commands_pre = [
   ["python", "-m", "pip", "list"],
   ["python", "-m", "pip", "check"]
@@ -67,7 +62,8 @@ commands_post = [
 ]
 
 [gh.python]
-"3.10" = ["upstream"]
+"3.10" = ["py3.10"]
 "3.11" = ["py3.11"]
 "3.12" = ["py3.12"]
 "3.13" = ["py3.13"]
+"3.14" = ["py3.14"]

--- a/tox.toml
+++ b/tox.toml
@@ -18,7 +18,12 @@ allowlist_externals = ["make"]
 
 [env.gis]
 description = "Run tests with extras under {basepython}"
-deps = ["numpy >= 1.25.0", "gdal == {env:GDAL_VERSION}.*", "setuptools >= 71.0"]
+deps = [
+  "numpy >= 1.25.0",
+  "gdal == {env:GDAL_VERSION}.*",
+  {replace = "if", condition = "env.RAVEN_HYDRO_UPSTREAM_BRANCH", then = ["git+https://github.com/Ouranosinc/raven-hydro.git@{env:RAVEN_HYDRO_UPSTREAM_BRANCH}"], extend = true},
+  "setuptools >= 71.0"
+]
 extras = ["gis", "raven-hydro"]
 commands = [
   ["python", "-m", "pip", "install", "--no-user", "--upgrade", "--force-reinstall", "--no-deps", "--no-binary", "gdal", "gdal[numpy]=={env:GDAL_VERSION}.*"],
@@ -32,6 +37,7 @@ labels = ["lint"]
 skip_install = true
 dependency_groups = ["lint"]
 extras = []
+deps = []
 commands = [
   ["make", "lint"]
 ]


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Updates the cookiecutter template:
  * Dependencies have been updated and synchronized
  * `h5py` is no longer reinstalled in `tox`
  * New `io` dependency-group for managing common file read/write libraries.
* Upstream `raven-hydro` versions are now installed in `tox` via the `RAVEN_HYDRO_UPSTREAM_BRANCH` environment variable
* `tox-gh` now fully supports Python3.14

### Does this PR introduce a breaking change?

Not really, no.

### Other information:

The `peter-evans` actions are being flagged by `zizmor` because they can easily be written using `bash` commands. I've set to ignore one set of them for now for convenience, but eventually we should rewrite these.