### PR TITLE
Add libjxl

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 
 Contributors: Trevor James Smith (:user:`Zeitsperre`).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* `ravenpy` now explicitly requires `libjxl` in order to perform raster operations. This library was previously bundled with other existing dependencies. (PR #617)
+
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Updates the cookiecutter template. (PR #600):

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ Python Installation (pip)
 
 .. warning::
 
-   In order to compile the Raven model (provided by the `raven-hydro` package, a C++ compiler (`GCC`, `Clang`, `MSVC`, etc.) and either `GNU Make` (Linux/macOS) or `Ninja` (Windows) must be exposed on the `$PATH`.
+   In order to compile the Raven model (provided by the `raven-hydro` PyPI package), a C++ compiler (`GCC`, `Clang`, `MSVC`, etc.) and either `GNU Make` (Linux/macOS) or `Ninja` (Windows) must be exposed on the `$PATH`.
 
 .. warning::
 
@@ -51,7 +51,7 @@ In order to perform this from Ubuntu/Debian:
 
     .. code-block:: console
 
-        sudo apt-get install gcc libnetcdf-dev gdal proj geos
+        sudo apt-get install gcc gdal geos libjxl-tools libnetcdf-dev proj
 
 Then, from your python environment, run:
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -60,6 +60,7 @@ dependencies:
   - fiona >=1.9.0
   - gdal >=3.1
   - geopandas >=1.0
+  - libjxl >=0.11.0
   - lxml
   - netcdf4 >=1.7.2
   - pyproj >=3.3.0


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Adds the `libjxl` library, needed for manipulating raster images. 

### Does this PR introduce a breaking change?

Yes-ish. Older versions of GDAL or associated library included support for JPEGXL, but this is no longer the case. `GeoPandas` still requires this library, so it is now explicitly marked as required.